### PR TITLE
fixed-fraction-radiation: Disable core radiation by default

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -2010,6 +2010,11 @@ in coronal equilibrium, using a simple formula from `I.H.Hutchinson Nucl. Fusion
 
 which has units of :math:`Wm^3` with :math:`T_e` in eV.
 
+By default, fixed fraction radiation is disabled in the core region. This represents the fact that
+the impurity will likely be coronal on closed field lines and feature reduced radiation. This 
+can prevent unphysical MARFE-like behaviour in deep detachment. This behaviour can be disabled
+by setting ``no_core_radiation=false`` in the impurity options block.
+
 To use this component you can just add it to the list of components and then
 configure the impurity fraction:
 

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -356,7 +356,7 @@ struct FixedFractionRadiation : public Component {
       .doc("Output radiation diagnostic?")
       .withDefault<bool>(false);
 
-    no_core_radiation = options["diagnose"]
+    no_core_radiation = options["no_core_radiation"]
       .doc("Set radiation to zero in core?")
       .withDefault<bool>(true);
 

--- a/include/fixed_fraction_radiation.hxx
+++ b/include/fixed_fraction_radiation.hxx
@@ -5,6 +5,8 @@
 #include <bout/constants.hxx>
 #include "component.hxx"
 
+using bout::globals::mesh;
+
 namespace {
   /// Carbon in coronal equilibrium
   /// From I.H.Hutchinson Nucl. Fusion 34 (10) 1337 - 1348 (1994)
@@ -354,6 +356,10 @@ struct FixedFractionRadiation : public Component {
       .doc("Output radiation diagnostic?")
       .withDefault<bool>(false);
 
+    no_core_radiation = options["diagnose"]
+      .doc("Set radiation to zero in core?")
+      .withDefault<bool>(true);
+
     radiation_multiplier = options["R_multiplier"]
       .doc("Scale the radiation rate by this factor")
       .withDefault<BoutReal>(1.0);
@@ -398,6 +404,20 @@ struct FixedFractionRadiation : public Component {
                             },
                             Ne.getRegion("RGN_NOBNDRY"))(Ne, Te);
 
+    // Disable radiation in core to emulate coronal conditions in the core
+    // This is a trick D. Moulton uses in SOLPS to avoid runaway fronts with fixed fraction
+    if (no_core_radiation) {
+      for (int x = mesh->xstart; x <= mesh->xend; x++) {
+        if (mesh->periodicY(x)) {
+          for (int y = mesh->ystart; y <= mesh->yend; y++) {
+            for (int z = mesh->zstart; z <= mesh->zend; z++) {
+              radiation(x, y, z) = 0.0;
+            }
+          }
+        }
+      }
+    }
+
     // Remove radiation from the electron energy source
     subtract(electrons["energy_source"], radiation);
   }
@@ -421,6 +441,7 @@ struct FixedFractionRadiation : public Component {
   BoutReal fraction; ///< Fixed fraction
 
   bool diagnose; ///< Output radiation diagnostic?
+  bool no_core_radiation; ///< Set radiation to zero in core?
   BoutReal radiation_multiplier; ///< Scale the radiation rate by this factor
   Field3D radiation; ///< For output diagnostic
 


### PR DESCRIPTION
In fixed fraction impurity radiation models, it's assumed that the impurity fraction and cooling curve remain constant throughout the domain. In reality, the impurities in the core have a much longer residence time than ones in the edge, which reduces their radiation power to coronal levels. 

Based on conversations with David Moulton, this can be emulated by simply disabling core radiation. This can prevent runaway detachment fronts.

This PR includes the option `no_core_radiation` and sets it to **True** by default.

- [x] Implement and simple test
- [x] Test in production MAST-U case
- [x] Documentation

![image](https://github.com/user-attachments/assets/cfddab66-7e53-4ef5-b58e-49f600679d1b)
![image](https://github.com/user-attachments/assets/c0410df2-3495-4ef3-a17c-4a7dc443aacb)
