### PR TITLE
Proper neutral momentum BC handling

### DIFF
--- a/include/neutral_boundary.hxx
+++ b/include/neutral_boundary.hxx
@@ -54,6 +54,7 @@ private:
   BoutReal target_fast_refl_fraction, sol_fast_refl_fraction, pfr_fast_refl_fraction; ///< Fraction of neutrals undergoing fast reflection
 
   Field3D target_energy_source, wall_energy_source; ///< Diagnostic for power loss
+  Field3D density_source, energy_source, momentum_source;
 
   bool diagnose; ///> Save diagnostic variables?
 


### PR DESCRIPTION
Neutrals now lose all of their momentum to the wall apart from what is reflected through thermal or fast reflection. Hopefully, this will reduce the unphysical bunching up of neutrals at the target in 1D.

- [x] Test implementation for upper_y
- [ ] Testing
- [ ] Implement for lower_y