### PR TITLE
Fix incorrect electron conductivity

### DIFF
--- a/docs/sphinx/components.rst
+++ b/docs/sphinx/components.rst
@@ -1310,6 +1310,13 @@ Note that with this definition we recover the `Braginskii expressions
 <https://farside.ph.utexas.edu/teaching/plasma/lectures1/node35.html>`_
 for e-i and i-i collision times.
 
+The electron-electron collision time definition follows Braginskii (note that Fitzpatrick uses 
+a different definition in his `notes <https://farside.ph.utexas.edu/teaching/plasma/Plasma/node41.html>`_,
+these are not consistent with Braginskii):
+
+.. math::
+   \nu_{ee} = \frac{ln \Lambda e^4 n_e} { 12 \pi^{3/2} \varepsilon_0^2 m_{e}^{1/2} T_{e}^{3/2} } 
+
 For conservation of momentum, the collision frequencies :math:`\nu_{ab}` and :math:`\nu_{ba}` are
 related by:
 

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -3,7 +3,7 @@
 #define EVOLVE_PRESSURE_H
 
 #include <bout/field3d.hxx>
-
+#include "../include/hermes_utils.hxx"
 #include "component.hxx"
 
 /// Evolves species pressure in time
@@ -81,6 +81,7 @@ private:
   bool thermal_conduction;    ///< Include thermal conduction?
   BoutReal kappa_coefficient; ///< Leading numerical coefficient in parallel heat flux calculation
   BoutReal kappa_limit_alpha; ///< Flux limit if >0
+  BoutReal default_kappa;     ///< default conductivity, changes depending on species
 
   bool p_div_v; ///< Use p*Div(v) form? False -> v * Grad(p)
 

--- a/include/hermes_utils.hxx
+++ b/include/hermes_utils.hxx
@@ -24,6 +24,23 @@ inline T clamp(const T& var, BoutReal lo, BoutReal hi, const std::string& rgn = 
   return result;
 }
 
+
+/// Identify species name string as electron, ion or neutral
+inline std::string identifySpeciesType(const std::string& species) {
+
+  std::string type = "";
+
+  if (species == "e") {
+    type = "electron";
+  } else if (species.find(std::string("+")) != std::string::npos) {
+    type = "ion";
+  } else {
+    type = "neutral";
+  }
+
+  return type;
+}
+
 template<typename T, typename = bout::utils::EnableIfField<T>>
 Ind3D indexAt(const T& f, int x, int y, int z) {
   int ny = f.getNy();


### PR DESCRIPTION
I am splitting selective-collisions (https://github.com/boutproject/hermes-3/pull/195) into individual PRs.

This one fixes the electron collision time mistake. Electron conductivity was off by sqrt(2) due to an inconsistency between the Fitzpatrick and Braginskii forms of the electron collision time, see https://github.com/boutproject/hermes-3/issues/234. 
