### PR TITLE
Add flooring to neutral pump 

### DIFF
--- a/include/recycling.hxx
+++ b/include/recycling.hxx
@@ -63,6 +63,8 @@ private:
   bool target_recycle, sol_recycle, pfr_recycle, neutral_pump;  ///< Flags for enabling recycling in different regions
   bool diagnose; ///< Save additional post-processing variables?
 
+  BoutReal density_floor, pressure_floor; ///< minimum values for Nn, Pn to avoid divide by zero
+
   Field3D density_source, energy_source; ///< Recycling particle and energy sources for all locations
   Field3D energy_flow_ylow, energy_flow_xlow; ///< Cell edge fluxes used for calculating fast recycling energy source
   Field3D particle_flow_xlow; ///< Radial wall particle fluxes for recycling calc. No need to get poloidal from here, it's calculated from sheath velocity

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -360,13 +360,13 @@ void Recycling::transform(Options& state) {
               // These are NOT communicated back into state and will exist only in this component
               // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
               // While enabling us to still calculate radial wall fluxes separately here
-              BoutReal nnguard = SQ(Nnlim[i]) / Nnlim[is];
-              BoutReal pnguard = SQ(Pnlim[i]) / Pnlim[is];
-              BoutReal tnguard = SQ(Tnlim[i]) / Tnlim[is];
+              BoutReal nnguard = SQ(Nn[i]) / Nnlim[is];
+              BoutReal pnguard = SQ(Pn[i]) / Pnlim[is];
+              BoutReal tnguard = SQ(Tn[i]) / Tnlim[is];
 
               // Calculate wall conditions
-              BoutReal nnsheath = 0.5 * (Nnlim[i] + nnguard);
-              BoutReal tnsheath = 0.5 * (Tnlim[i] + tnguard);
+              BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
+              BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
               BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
 
               // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta
@@ -460,13 +460,13 @@ void Recycling::transform(Options& state) {
                 // These are NOT communicated back into state and will exist only in this component
                 // This will prevent neutrals leaking through cross-field transport from neutral_mixed or other components
                 // While enabling us to still calculate radial wall fluxes separately here
-                BoutReal nnguard = SQ(Nnlim[i]) / Nnlim[is];
-                BoutReal pnguard = SQ(Pnlim[i]) / Pnlim[is];
-                BoutReal tnguard = SQ(Tnlim[i]) / Tnlim[is];
+                BoutReal nnguard = SQ(Nn[i]) / Nnlim[is];
+                BoutReal pnguard = SQ(Pn[i]) / Pnlim[is];
+                BoutReal tnguard = SQ(Tn[i]) / Tnlim[is];
 
                 // Calculate wall conditions
-                BoutReal nnsheath = 0.5 * (Nnlim[i] + nnguard);
-                BoutReal tnsheath = 0.5 * (Tnlim[i] + tnguard);
+                BoutReal nnsheath = 0.5 * (Nn[i] + nnguard);
+                BoutReal tnsheath = 0.5 * (Tn[i] + tnguard);
                 BoutReal v_th = 0.25 * sqrt( 8*tnsheath / (PI*AAn) );   // Stangeby p.69 eqns. 2.21, 2.24
 
                 // Convert dy to poloidal length: dl = dy * sqrt(g22) = dy * h_theta

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -508,18 +508,6 @@ void Recycling::transform(Options& state) {
       }
     }
 
-    for(int ix=0; ix < mesh->LocalNx ; ix++){
-      for(int iy=0; iy < mesh->LocalNy ; iy++){
-          for(int iz=0; iz < mesh->LocalNz; iz++){
-
-            // output << "("" << ix << "Y:" << iy << "Z:" << iz << "T:" << Tn(ix, iy, iz) << "  ";
-            std::string string_count = std::string("(") + std::to_string(ix) + std::string(",") + std::to_string(iy)+ std::string(",") + std::to_string(iz) + std::string(")");
-            output << string_count + std::string(": ") + std::to_string(density_source(ix,iy,iz)) + std::string("; ");
-          }
-      }
-    output << "\n";
-    }
-
     // Put the updated sources back into the state
     set<Field3D>(species_to["density_source"], density_source);
     set<Field3D>(species_to["energy_source"], energy_source);

--- a/src/recycling.cxx
+++ b/src/recycling.cxx
@@ -572,23 +572,31 @@ void Recycling::outputVars(Options& state) {
 
       // Neutral pump
       if (neutral_pump) {
-        set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}],
-                       channel.pump_density_source,
-                       {{"time_dimension", "t"},
-                        {"units", "m^-3 s^-1"},
-                        {"conversion", Nnorm * Omega_ci},
-                        {"standard_name", "particle source"},
-                        {"long_name", std::string("Pump recycling particle source of ") + channel.to},
-                        {"source", "recycling"}});
 
-        set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}],
-                       channel.pump_energy_source,
-                       {{"time_dimension", "t"},
-                        {"units", "W m^-3"},
-                        {"conversion", Pnorm * Omega_ci},
-                        {"standard_name", "energy source"},
-                        {"long_name", std::string("Pump recycling energy source of ") + channel.to},
-                        {"source", "recycling"}});
+        if (channel.pump_density_source.isAllocated()) { 
+          set_with_attrs(state[{std::string("S") + channel.to + std::string("_pump")}],
+                        channel.pump_density_source,
+                        {{"time_dimension", "t"},
+                          {"units", "m^-3 s^-1"},
+                          {"conversion", Nnorm * Omega_ci},
+                          {"standard_name", "particle source"},
+                          {"long_name", std::string("Pump recycling particle source of ") + channel.to},
+                          {"source", "recycling"}});
+
+          set_with_attrs(state[{std::string("E") + channel.to + std::string("_pump")}],
+                        channel.pump_energy_source,
+                        {{"time_dimension", "t"},
+                          {"units", "W m^-3"},
+                          {"conversion", Pnorm * Omega_ci},
+                          {"standard_name", "energy source"},
+                          {"long_name", std::string("Pump recycling energy source of ") + channel.to},
+                          {"source", "recycling"}});
+        } else {
+          throw BoutException("Error: neutral pump sources unallocated, likely because recycling " 
+            "on the relevant surface is disabled. Check that all boundaries with a neutral pump " 
+            "have recycling enabled!");
+        }
+
       }
 
     }


### PR DESCRIPTION
Solves https://github.com/boutproject/hermes-3/issues/250
Solves https://github.com/boutproject/hermes-3/issues/305

There has been a bug for ages which causes a crash when starting a case with radial recycling from scratch. Turns out it's actually a problem with the pump. I put a free BC in there:

https://github.com/boutproject/hermes-3/blob/a33e1ba046a4090ac588dc53ab1ff0017515c0ff/src/recycling.cxx#L352-L358

This is a problem as neutrals are often initialised with zero density, causing a divide by zero and the error message:

> ====== Exception thrown ======
Setting invalid value for 'species:d:density_source'

I have now floored density, pressure and temperature:

https://github.com/boutproject/hermes-3/blob/d8232ba74430d92cb21fb462d90e300482c1161c/src/recycling.cxx#L175-L177

The floored values are only used in the calculations of sheath neutral quantities, nowhere else as I can't spot any other bits that would require it:

https://github.com/boutproject/hermes-3/blob/d8232ba74430d92cb21fb462d90e300482c1161c/src/recycling.cxx#L359-L370
