### PR TITLE
sheath_boundary_simple: minor refactor, add diagnostics

### DIFF
--- a/include/sheath_boundary_simple.hxx
+++ b/include/sheath_boundary_simple.hxx
@@ -73,6 +73,7 @@ struct SheathBoundarySimple : public Component {
   ///
   ///
   void transform(Options &state) override;
+  void outputVars(Options &state) override;
 private:
   BoutReal Ge; // Secondary electron emission coefficient
   BoutReal sin_alpha; // sin of angle between magnetic field and wall.
@@ -87,6 +88,13 @@ private:
   bool always_set_phi; ///< Set phi field?
 
   Field3D wall_potential; ///< Voltage of the wall. Normalised units.
+
+  Field3D hflux_e;  // Electron heat flux through sheath
+  Field3D phi; // Phi at sheath
+  Field3D ion_sum; // Sum of ion current at sheath
+
+  bool diagnose; // Save diagnostic variables?
+  Options diagnostics;   // Options object to store diagnostic fields like a dict
 
   bool no_flow; ///< No flow speed, only remove energy
 


### PR DESCRIPTION
This PR is split off from https://github.com/boutproject/hermes-3/pull/195. It has been used in the verification against the 1D code ReMKiT1D. Note that this is for `sheath_boundary_simple` only. It is aimed to merge all the various sheath boundary components into one over the next few months. 

**What's new**
How the sheath boundary works in `sheath_boundary_simple` is now easier to understand by having expanded the calculations by a few steps, e.g. instead of this, which obscures the target cross-sectional area and cell volume:

```
// Multiply by cell area to get power
BoutReal heatflow = q * (coord->J[i] + coord->J[ip])
                / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]));  // This omits dx*dz because we divide by dx*dz next

// Divide by volume of cell to get energy loss rate (> 0)
BoutReal power = heatflow / (coord->dy[i] * coord->J[i]);

electron_energy_source[i] -= power;

// Diagnostic contains energy removed in the sheath
electron_sheath_power_ylow[ip] += heatflow * coord->dx[i] * coord->dz[i];    // upper Y, so power placed in first guard cell
```

To this, where the areas and volumes are exposed, variables are named in a more consistent way and units are specified.
```
q -= (2.5 * tesheath + 0.5 * Me * SQ(vesheath)) * nesheath * vesheath;

// Cross-sectional area in XZ plane and cell volume
BoutReal da = (coord->J[i] + coord->J[ip]) / (sqrt(coord->g_22[i]) + sqrt(coord->g_22[ip]))
                * 0.5*(coord->dx[i] + coord->dx[ip]) * 0.5*(coord->dz[i] + coord->dz[ip]);   // [m^2]
BoutReal dv = (coord->dx[i] * coord->dy[i] * coord->dz[i] * coord->J[i]);  // [m^3]

// Get power and energy source
BoutReal heatflow = q * da;   // [W]
BoutReal power = heatflow / dv;  // [Wm^-3]
electron_energy_source[i] -= power;

// Total heat flux for diagnostic purposes
q = gamma_e * tesheath * nesheath * vesheath;   // [Wm^-2]
hflux_e[i] -= q * da / dv;   // [Wm^-3]
electron_sheath_power_ylow[ip] += heatflow;    // [W]  Upper Y, so sheath boundary power on ylow side of inner guard cell
```

There are also diagnostics for total energy and particle losses due to the sheath, e.g. `Ed+_sheath` and `Sd+_sheath`.
