### PR TITLE
`neutral_mixed` MMS tests and expanded differential operator MMS tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,9 @@ if(HERMES_TESTS)
     add_test(NAME differential_operators_mms_nonorthogonal
            WORKING_DIRECTORY tests/mms/
            COMMAND python3 nonorthogonal_test.py)
+    add_test(NAME rhs_mms_neutral_mixed
+           WORKING_DIRECTORY tests/mms/
+           COMMAND python3 neutral_mixed_ddt_test.py)
   endif()
 endif()
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -53,6 +53,7 @@ private:
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
   BoutReal rnn_override; ///< Rnn input for testing
   BoutReal density_norm, pressure_norm; ///< Normalisations
+  BoutReal momentum_norm; ///< Normalisations
 
   bool neutral_viscosity; ///< include viscosity?
   bool neutral_conduction; ///< Include heat conduction?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -65,7 +65,7 @@ private:
   bool lax_flux; ///< Use Lax flux for advection terms
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 
-  Field3D density_source, pressure_source; ///< External input source
+  Field3D density_source, pressure_source, momentum_source; ///< External input source
   Field3D Sn, Sp, Snv; ///< Particle, pressure and momentum source
   Field3D sound_speed; ///< Sound speed for use with Lax flux
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -51,7 +51,8 @@ private:
 
   BoutReal flux_limit; ///< Diffusive flux limit
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
-
+  BoutReal rnn_override;
+  
   bool neutral_viscosity; ///< include viscosity?
   bool neutral_conduction; ///< Include heat conduction?
   bool evolve_momentum; ///< Evolve parallel momentum?

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -51,12 +51,14 @@ private:
 
   BoutReal flux_limit; ///< Diffusive flux limit
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient
-  BoutReal rnn_override;
-  
+  BoutReal rnn_override; ///< Rnn input for testing
+  BoutReal density_norm, pressure_norm; ///< Normalisations
+
   bool neutral_viscosity; ///< include viscosity?
   bool neutral_conduction; ///< Include heat conduction?
   bool evolve_momentum; ///< Evolve parallel momentum?
-  
+  bool normalise_sources; ///< Normalise input sources?
+
   Field3D kappa_n, eta_n; ///< Neutral conduction and viscosity
 
   bool precondition {true}; ///< Enable preconditioner?

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -364,14 +364,14 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral density
   TRACE("Neutral density");
   ddt(Nn) =
-    - FV::Div_par_mod<ParLimiter>(
-                  Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
+    //- FV::Div_par_mod<ParLimiter>(
+    //              Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
                   
     + Div_a_Grad_perp_nonorthog(DnnNn, logPnlim,
         pf_adv_perp_xlow, pf_adv_perp_ylow); // Perpendicular diffusion
    // + Div_a_Grad_perp_flows(DnnNn, logPnlim,
    //                                pf_adv_perp_xlow,
-   //                               pf_adv_perp_ylow);    // Perpendicular advection
+   //                                pf_adv_perp_ylow);    // Perpendicular advection
     ;
 
   Sn = density_source; // Save for possible output
@@ -384,10 +384,10 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = - FV::Div_par_mod<ParLimiter>(               // Parallel advection
-                    Pn, Vn, sound_speed, ef_adv_par_ylow)
+  ddt(Pn) = //- FV::Div_par_mod<ParLimiter>(               // Parallel advection
+            //        Pn, Vn, sound_speed, ef_adv_par_ylow)
 
-            - (2. / 3) * Pn * Div_par(Vn)                // Compression
+            //- (2. / 3) * Pn * Div_par(Vn)                // Compression
 
             + (5. / 3) * Div_a_Grad_perp_nonorthog(DnnNn, logPnlim,
                            ef_adv_perp_xlow, ef_adv_perp_ylow) // Perpendicular diffusion
@@ -409,9 +409,9 @@ void NeutralMixed::finally(const Options& state) {
              //       kappa_n, Tn,                            // Perpendicular conduction
              //       ef_cond_perp_xlow, ef_cond_perp_ylow)
 
-            + (2. / 3) * Div_par_K_Grad_par_mod(kappa_n, Tn,           // Parallel conduction 
-                      ef_cond_par_ylow,        
-                      false)  // No conduction through target boundary
+            // + (2. / 3) * Div_par_K_Grad_par_mod(kappa_n, Tn,           // Parallel conduction 
+            //          ef_cond_par_ylow,        
+            //          false)  // No conduction through target boundary
     ;
 
     // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
@@ -433,10 +433,10 @@ void NeutralMixed::finally(const Options& state) {
     TRACE("Neutral momentum");
 
     ddt(NVn) =
-        -AA * FV::Div_par_fvv<ParLimiter>(             // Momentum flow
-              Nnlim, Vn, sound_speed)                  
+       // -AA * FV::Div_par_fvv<ParLimiter>(             // Momentum flow
+       //       Nnlim, Vn, sound_speed)                  
 
-        - Grad_par(Pn)                                 // Pressure gradient
+       // - Grad_par(Pn)                                 // Pressure gradient
         
         + Div_a_Grad_perp_nonorthog(DnnNVn, logPnlim, 
                       mf_adv_perp_xlow, mf_adv_perp_ylow) // Perpendicular diffusion
@@ -461,10 +461,10 @@ void NeutralMixed::finally(const Options& state) {
                                // mf_visc_perp_xlow,
                                // mf_visc_perp_ylow)    
                               
-                              + AA * Div_par_K_Grad_par_mod(               // Parallel viscosity 
-                                eta_n, Vn,
-                                mf_visc_par_ylow,
-                                false) // No viscosity through target boundary
+                              //+ AA * Div_par_K_Grad_par_mod(               // Parallel viscosity 
+                              //  eta_n, Vn,
+                              //  mf_visc_par_ylow,
+                              //  false) // No viscosity through target boundary
                           ;
 
       ddt(NVn) += viscosity_source;

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -118,8 +118,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   density_source =
       alloptions[std::string("N") + name]["source"]
           .doc("Source term in ddt(N" + name + std::string("). Units [m^-3/s]"))
-          .withDefault(density_source);
-      // / (Nnorm * Omega_ci);
+          .withDefault(density_source)
+      / (Nnorm * Omega_ci);
 
   // Try to read the pressure source from the mesh
   // Units of Pascals per second
@@ -129,8 +129,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   pressure_source = alloptions[std::string("P") + name]["source"]
                         .doc(std::string("Source term in ddt(P") + name
                              + std::string("). Units [N/m^2/s]"))
-                        .withDefault(pressure_source);
-                    // / (SI::qe * Nnorm * Tnorm * Omega_ci);
+                        .withDefault(pressure_source)
+                    / (SI::qe * Nnorm * Tnorm * Omega_ci);
 
   // Set boundary condition defaults: Neumann for all but the diffusivity.
   // The dirichlet on diffusivity ensures no radial flux.

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -363,7 +363,6 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
-  pf_adv_par_ylow = 0.0; // zero flow to permit following lines to be commented out
   ddt(Nn) =
     //- FV::Div_par_mod<ParLimiter>(
     //              Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
@@ -384,7 +383,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral pressure
   TRACE("Neutral pressure");
-  ef_adv_par_ylow = 0.0; // zero flow to permit following lines to be commented out
+
   ddt(Pn) = //- FV::Div_par_mod<ParLimiter>(               // Parallel advection
             //        Pn, Vn, sound_speed, ef_adv_par_ylow)
 
@@ -403,7 +402,6 @@ void NeutralMixed::finally(const Options& state) {
   ef_adv_perp_ylow *= 5/2;
 
   if (neutral_conduction) {
-    ef_cond_par_ylow = 0.0; // needed to allow following line to be commented out
     ddt(Pn) += 
                (2. / 3) * Div_a_Grad_perp_nonorthog(kappa_n, Tn,
                              ef_cond_perp_xlow, ef_cond_perp_ylow) // Perpendicular diffusion
@@ -455,7 +453,7 @@ void NeutralMixed::finally(const Options& state) {
       // Gases", CUP 1952 Ferziger, Kaper "Mathematical Theory of
       // Transport Processes in Gases", 1972
       // eta_n = (2. / 5) * kappa_n;
-      mf_visc_par_ylow = 0.0; // needed to permit following lines to be commented out
+
       Field3D viscosity_source = AA * Div_a_Grad_perp_nonorthog(eta_n, Vn,
                                         mf_visc_perp_xlow, mf_visc_perp_ylow) // Perpendicular viscosity
                                // AA * Div_a_Grad_perp_flows(

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -310,8 +310,8 @@ void NeutralMixed::finally(const Options& state) {
   Dnn.applyBoundary();
 
   // Neutral diffusion parameters have the same boundary condition as Dnn
-  DnnNn = Dnn * Nnlim;
-  DnnPn = Dnn * Pnlim;
+  DnnNn = 1.0; //Dnn * Nnlim;
+  DnnPn = 1.0; //Dnn * Pnlim;
   DnnNVn = Dnn * NVn;
 
   DnnPn.applyBoundary();

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -364,14 +364,14 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral density
   TRACE("Neutral density");
   ddt(Nn) =
-    //- FV::Div_par_mod<ParLimiter>(
-    //              Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
+    - FV::Div_par_mod<ParLimiter>(
+                  Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
                   
     + Div_a_Grad_perp_nonorthog(DnnNn, logPnlim,
         pf_adv_perp_xlow, pf_adv_perp_ylow); // Perpendicular diffusion
    // + Div_a_Grad_perp_flows(DnnNn, logPnlim,
    //                                pf_adv_perp_xlow,
-   //                                pf_adv_perp_ylow);    // Perpendicular advection
+   //                               pf_adv_perp_ylow);    // Perpendicular advection
     ;
 
   Sn = density_source; // Save for possible output
@@ -384,10 +384,10 @@ void NeutralMixed::finally(const Options& state) {
   // Neutral pressure
   TRACE("Neutral pressure");
 
-  ddt(Pn) = //- FV::Div_par_mod<ParLimiter>(               // Parallel advection
-            //        Pn, Vn, sound_speed, ef_adv_par_ylow)
+  ddt(Pn) = - FV::Div_par_mod<ParLimiter>(               // Parallel advection
+                    Pn, Vn, sound_speed, ef_adv_par_ylow)
 
-            //- (2. / 3) * Pn * Div_par(Vn)                // Compression
+            - (2. / 3) * Pn * Div_par(Vn)                // Compression
 
             + (5. / 3) * Div_a_Grad_perp_nonorthog(DnnNn, logPnlim,
                            ef_adv_perp_xlow, ef_adv_perp_ylow) // Perpendicular diffusion
@@ -409,9 +409,9 @@ void NeutralMixed::finally(const Options& state) {
              //       kappa_n, Tn,                            // Perpendicular conduction
              //       ef_cond_perp_xlow, ef_cond_perp_ylow)
 
-            // + (2. / 3) * Div_par_K_Grad_par_mod(kappa_n, Tn,           // Parallel conduction 
-            //          ef_cond_par_ylow,        
-            //          false)  // No conduction through target boundary
+            + (2. / 3) * Div_par_K_Grad_par_mod(kappa_n, Tn,           // Parallel conduction 
+                      ef_cond_par_ylow,        
+                      false)  // No conduction through target boundary
     ;
 
     // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
@@ -433,10 +433,10 @@ void NeutralMixed::finally(const Options& state) {
     TRACE("Neutral momentum");
 
     ddt(NVn) =
-       // -AA * FV::Div_par_fvv<ParLimiter>(             // Momentum flow
-       //       Nnlim, Vn, sound_speed)                  
+        -AA * FV::Div_par_fvv<ParLimiter>(             // Momentum flow
+              Nnlim, Vn, sound_speed)                  
 
-       // - Grad_par(Pn)                                 // Pressure gradient
+        - Grad_par(Pn)                                 // Pressure gradient
         
         + Div_a_Grad_perp_nonorthog(DnnNVn, logPnlim, 
                       mf_adv_perp_xlow, mf_adv_perp_ylow) // Perpendicular diffusion
@@ -461,10 +461,10 @@ void NeutralMixed::finally(const Options& state) {
                                // mf_visc_perp_xlow,
                                // mf_visc_perp_ylow)    
                               
-                              //+ AA * Div_par_K_Grad_par_mod(               // Parallel viscosity 
-                              //  eta_n, Vn,
-                              //  mf_visc_par_ylow,
-                              //  false) // No viscosity through target boundary
+                              + AA * Div_par_K_Grad_par_mod(               // Parallel viscosity 
+                                eta_n, Vn,
+                                mf_visc_par_ylow,
+                                false) // No viscosity through target boundary
                           ;
 
       ddt(NVn) += viscosity_source;

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -118,8 +118,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   density_source =
       alloptions[std::string("N") + name]["source"]
           .doc("Source term in ddt(N" + name + std::string("). Units [m^-3/s]"))
-          .withDefault(density_source)
-      / (Nnorm * Omega_ci);
+          .withDefault(density_source);
+      // / (Nnorm * Omega_ci);
 
   // Try to read the pressure source from the mesh
   // Units of Pascals per second
@@ -129,8 +129,8 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   pressure_source = alloptions[std::string("P") + name]["source"]
                         .doc(std::string("Source term in ddt(P") + name
                              + std::string("). Units [N/m^2/s]"))
-                        .withDefault(pressure_source)
-                    / (SI::qe * Nnorm * Tnorm * Omega_ci);
+                        .withDefault(pressure_source);
+                    // / (SI::qe * Nnorm * Tnorm * Omega_ci);
 
   // Set boundary condition defaults: Neumann for all but the diffusivity.
   // The dirichlet on diffusivity ensures no radial flux.

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -363,6 +363,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral density
   TRACE("Neutral density");
+  pf_adv_par_ylow = 0.0; // zero flow to permit following lines to be commented out
   ddt(Nn) =
     //- FV::Div_par_mod<ParLimiter>(
     //              Nn, Vn, sound_speed, pf_adv_par_ylow) // Parallel advection
@@ -383,7 +384,7 @@ void NeutralMixed::finally(const Options& state) {
   /////////////////////////////////////////////////////
   // Neutral pressure
   TRACE("Neutral pressure");
-
+  ef_adv_par_ylow = 0.0; // zero flow to permit following lines to be commented out
   ddt(Pn) = //- FV::Div_par_mod<ParLimiter>(               // Parallel advection
             //        Pn, Vn, sound_speed, ef_adv_par_ylow)
 
@@ -402,6 +403,7 @@ void NeutralMixed::finally(const Options& state) {
   ef_adv_perp_ylow *= 5/2;
 
   if (neutral_conduction) {
+    ef_cond_par_ylow = 0.0; // needed to allow following line to be commented out
     ddt(Pn) += 
                (2. / 3) * Div_a_Grad_perp_nonorthog(kappa_n, Tn,
                              ef_cond_perp_xlow, ef_cond_perp_ylow) // Perpendicular diffusion
@@ -453,7 +455,7 @@ void NeutralMixed::finally(const Options& state) {
       // Gases", CUP 1952 Ferziger, Kaper "Mathematical Theory of
       // Transport Processes in Gases", 1972
       // eta_n = (2. / 5) * kappa_n;
-
+      mf_visc_par_ylow = 0.0; // needed to permit following lines to be commented out
       Field3D viscosity_source = AA * Div_a_Grad_perp_nonorthog(eta_n, Vn,
                                         mf_visc_perp_xlow, mf_visc_perp_ylow) // Perpendicular viscosity
                                // AA * Div_a_Grad_perp_flows(

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -310,8 +310,8 @@ void NeutralMixed::finally(const Options& state) {
   Dnn.applyBoundary();
 
   // Neutral diffusion parameters have the same boundary condition as Dnn
-  DnnNn = 1.0; //Dnn * Nnlim;
-  DnnPn = 1.0; //Dnn * Pnlim;
+  DnnNn = Dnn * Nnlim;
+  DnnPn = Dnn * Pnlim;
   DnnNVn = Dnn * NVn;
 
   DnnPn.applyBoundary();

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -396,7 +396,7 @@ void NeutralMixed::finally(const Options& state) {
 
             - (2. / 3) * Pn * Div_par(Vn)                // Compression
 
-            + (5. / 3) * Div_a_Grad_perp_nonorthog(DnnNn, logPnlim,
+            + (5. / 3) * Div_a_Grad_perp_nonorthog(DnnPn, logPnlim,
                            ef_adv_perp_xlow, ef_adv_perp_ylow) // Perpendicular diffusion
             //+ (5. / 3) * Div_a_Grad_perp_flows(          // Perpendicular advection
             //        DnnPn, logPnlim,

--- a/tests/mms/BOUT.inp.neutral_mixed.template
+++ b/tests/mms/BOUT.inp.neutral_mixed.template
@@ -1,5 +1,5 @@
 nout = 0
-timestep = 100.0
+timestep = 1.0
 MYG=1
 MXG=2
 NXPE=1
@@ -16,9 +16,9 @@ rtol = 1e-10
 [hermes]
 components = (d+, d, e)
 
-Nnorm = 1e19  # Reference density [m^-3]
+Nnorm = 1  # Reference density [m^-3]
 Bnorm = 1   # Reference magnetic field [T]
-Tnorm = 75   # Reference temperature [eV]
+Tnorm = 1   # Reference temperature [eV]
 recalculate_metric = false
 
 ################################################################

--- a/tests/mms/BOUT.inp.neutral_mixed.template
+++ b/tests/mms/BOUT.inp.neutral_mixed.template
@@ -1,5 +1,5 @@
-nout = 1
-timestep = 10000.0
+nout = 0
+timestep = 100.0
 MYG=1
 MXG=2
 NXPE=1

--- a/tests/mms/BOUT.inp.neutral_mixed.template
+++ b/tests/mms/BOUT.inp.neutral_mixed.template
@@ -1,5 +1,5 @@
 nout = 1
-timestep = 50.0
+timestep = 10000.0
 MYG=1
 MXG=2
 NXPE=1
@@ -11,7 +11,7 @@ mxstep = 1e5
 
 mxorder = 3
 atol = 1e-12
-rtol = 1e-5
+rtol = 1e-10
 
 [hermes]
 components = (d+, d, e)

--- a/tests/mms/BOUT.inp.neutral_mixed.template
+++ b/tests/mms/BOUT.inp.neutral_mixed.template
@@ -20,7 +20,7 @@ Nnorm = 1  # Reference density [m^-3]
 Bnorm = 1   # Reference magnetic field [T]
 Tnorm = 1   # Reference temperature [eV]
 recalculate_metric = false
-
+normalise_metric = false
 ################################################################
 # Ions
 

--- a/tests/mms/BOUT.inp.neutral_mixed.template
+++ b/tests/mms/BOUT.inp.neutral_mixed.template
@@ -1,0 +1,47 @@
+nout = 1
+timestep = 50.0
+MYG=1
+MXG=2
+NXPE=1
+
+[solver]
+type = cvode
+use_precon = true
+mxstep = 1e5
+
+mxorder = 3
+atol = 1e-12
+rtol = 1e-5
+
+[hermes]
+components = (d+, d, e)
+
+Nnorm = 1e19  # Reference density [m^-3]
+Bnorm = 1   # Reference magnetic field [T]
+Tnorm = 75   # Reference temperature [eV]
+recalculate_metric = false
+
+################################################################
+# Ions
+
+[d+]
+type = fixed_density, fixed_velocity, fixed_temperature
+
+AA = 2
+charge = 1
+density = 1.0
+velocity = 0.0
+temperature = 1.0
+diagnose = true
+
+#################################################################
+## Electrons
+[e]
+type = fixed_density, fixed_velocity, fixed_temperature
+AA = 1/1836
+charge = -1
+density = 1.0
+velocity = 0.0
+temperature = 1.0
+diagnose = true
+

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -234,6 +234,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    g12_str = test_input["g12_string"]
    g13_str = test_input["g13_string"]
    g23_str = test_input["g23_string"]
+   neutral_conduction = test_input["neutral_conduction"]
    base_test_dir = test_input["test_dir"]
    interactive_plots = test_input["interactive_plots"]
 
@@ -295,6 +296,8 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    flux_limit = -1.0
    diffusion_limit = -1.0
    lax_flux = false
+   density_floor = 1.0e-15
+   neutral_conduction = {neutral_conduction}
    [Nd]
 
    function = {Nd_string}

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -380,33 +380,38 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
    function_list = ["ddt(Nd)", "ddt(Pd)"]
-   if evolve_momentum:
+   if evolve_momentum and not conservation_test:
        function_list.append("ddt(NVd)")
 
-   for varstring in function_list: #, "Nd", "Pd"
-      label = varstring
+   for varstring in function_list:
       expected_slope = 2.0
       l2norm = []
       nylist = []
       dylist = []
       for m in range(0,ntest):
-         #print(varstring)
-         numerical = collectvar(datasets, varstring, m)
+         if varstring == "ddt(Pd)" and evolve_momentum and conservation_test:
+            NVd = collectvar(datasets, "NVd", m)
+            Nd = collectvar(datasets, "Nd", m)
+            Vd = NVd/(Nd*mass)
+            numerical = (3.0/2.0)*collectvar(datasets, "ddt(Pd)", m) + Vd*collectvar(datasets, "ddt(NVd)", m)
+            label = "ddt(Ed) = 3/2 ddt(Pd) + Vd * ddt(NVd)"
+         else:
+            label = varstring
+            numerical = collectvar(datasets, varstring, m)
          normvar = (collectvar(datasets, varstring[4:-1], m))[s]
          dx = (collectvar(datasets, "dx", m))[sxy]
          dy = (collectvar(datasets, "dy", m))[sxy]
          dz = (collectvar(datasets, "dz", m))[sxy]
          J = (collectvar(datasets, "J", m))[sxy]
-         #if label[0:3] == "ddt":
          error_values = (numerical)[s]
-         #else:
+         
          if conservation_test:
             thisl2 = np.abs(volume_integral(error_values,dx,dy,dz,J)/
                            volume_integral(normvar,dx,dy,dz,J))
          else:
             thisl2 = np.sqrt(volume_integral(error_values**2,dx,dy,dz,J)/
                               volume_integral(normvar**2,dx,dy,dz,J))
-            #print("thisl2",thisl2)
+         #print("thisl2",thisl2)
          l2norm.append(thisl2)
          nylist.append(numerical.shape[1])
          # proxy for grid spacing

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -214,3 +214,216 @@ def run_manufactured_solutions_test(test_input):
          success = False
 
    return success, output_message
+
+def run_neutral_mixed_manufactured_solutions_test(test_input):
+   # expand inputs from input dictionary
+   # the number of grids generated
+   ntest = test_input["ntest"]
+   # the minimum number of points in each of the x, y, z grids in the test
+   # the number of points in the ith test is ngrid*i
+   nnbase = test_input["ngrid"]
+   # list of [name, symbolic string, expected convergence order]
+   astr = test_input["a_string"]
+   fstr = test_input["f_string"]
+   g11_str = test_input["g11_string"]
+   g22_str = test_input["g22_string"]
+   g33_str = test_input["g33_string"]
+   g12_str = test_input["g12_string"]
+   g13_str = test_input["g13_string"]
+   g23_str = test_input["g23_string"]
+   base_test_dir = test_input["test_dir"]
+   interactive_plots = test_input["interactive_plots"]
+
+   # create directory 
+   if not os.path.isdir(base_test_dir):
+       os.system("mkdir "+base_test_dir)
+   workdirs = []
+   # make test for each resolution based on template file
+   for i in range(0,ntest):
+      workdir = f"{base_test_dir}/slab-mms-test-{i}"
+      workdirs.append(workdir)
+      # create directory 
+      if not os.path.isdir(workdir):
+         os.system("mkdir "+workdir)
+      # copy template
+      file = workdir+"/BOUT.inp"
+      os.system(f"cp BOUT.inp.neutral_mixed.template "+file)
+      # update with mesh values for test
+      nn = nnbase*(i+1) # number of points in each grid
+      dd = 2.0*np.pi/nn # y z grid spacing, z, y on [0, 2pi]
+      ddx = 1.0/(nn-4) # x grid spacing to account for guard cells, x on [0,1] 
+      # symmetricGlobalX = true ensures that x = 0 and x = 1 sits
+      # halfway between the last true grid point and the first guard point.
+      with open(file,"a") as file:
+         mesh_string = f"""
+   [mesh]
+   symmetricGlobalX = true
+   extrapolate_y = false
+   extrapolate_x= false
+   
+   nx = {nn}
+   dx = {ddx}
+   ny = {nn}
+   dy = {dd}
+   nz = {nn}
+   dz = {dd}
+
+   g11 = {g11_str}
+   g22 = {g22_str}
+   g33 = {g33_str}
+   g12 = {g12_str}
+   g23 = {g23_str}
+   g13 = {g13_str}
+   
+   #################################################################
+   # Neutrals
+
+   [d]
+   type = neutral_mixed
+
+   AA = 2
+
+   diagnose = true
+   output_ddt = true
+   evolve_momentum = false
+   precondition = true
+   diagnose = true
+   [Nd]
+
+   function = 1 - 0.5*x^2
+   bndry_core = neumann
+   bndry_all = neumann
+
+   [Pd]
+   function = 1 - 0.5*x^2
+   bndry_core = neumann
+   bndry_all = neumann
+   """
+         file.write(mesh_string.replace("**","^"))
+
+      # run job on this input
+      print("../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt")
+      os.system("../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt")
+
+   # now analyse the results of the test
+   # this slice avoids including guard cells in the test
+   # need guard cells in x (assume 2 here) and guard cells in y (assume 1)
+   # no guard cells in z
+   # s = slice(2, -2), slice(1, -1), slice(None)
+
+   # # a dictionary of plot data, filled later on
+   # plot_data = dict()
+
+   # # open the series of "workdir/BOUT.0.nc" files, 
+   # # saving them in a list `datasets`
+   # datasets = []
+   # for workdir in workdirs:
+   #    boutmeshpath = workdir+"/"+f'BOUT.0.nc'
+   #    boutinppath = workdir+"/"+'BOUT.inp'
+   #    datasets.append(open_boutdataset(boutmeshpath, inputfilepath=boutinppath, keep_yboundaries=False))
+
+   # # make a easy scan over the two operators, generalisation to N operators possible
+   # for i, values in enumerate(differential_operator_test_list):
+   #    label = values[0]
+   #    expected_slope = values[2]
+   #    l2norm = []
+   #    nylist = []
+   #    dylist = []
+   #    for m in range(0,ntest):
+   #       numerical = collectvar(datasets, f"result_{i}", m)
+   #       expected = collectvar(datasets, f"expected_result_{i}", m)
+   #       xx = collectvar(datasets, "x_input", m)
+   #       yy = collectvar(datasets, "y_input", m)
+   #       zz = collectvar(datasets, "z_input", m)
+   #       ff = collectvar(datasets, "f", m)
+   #       aa = collectvar(datasets, "a", m)
+      
+   #       error_values = (numerical - expected)[s]
+   #       thisl2 = np.sqrt(np.mean(error_values**2))
+   #       l2norm.append(thisl2)
+   #       nylist.append(yy.shape[1])
+   #       # proxy for grid spacing
+   #       dylist.append(1.0/yy.shape[1])
+               
+   #    # cast lists as numpy arrays for further manipulation
+   #    l2norm = np.array(l2norm)
+   #    #print("test error: ",l2norm)
+   #    nylist = np.array(nylist)
+   #    dylist = np.array(dylist)
+      
+   #    # find linear fit coefficients to test convergence rate
+   #    # and construct fit function for plotting
+   #    try:
+   #       logl2norm = np.log(l2norm)
+   #       logdylist = np.log(dylist)
+   #       outvals = curve_fit(lin_func,logdylist,logl2norm)
+   #       coeffs = outvals[0]
+   #       slope = coeffs[0] # the convergence order
+   #       offset = coeffs[1]
+   #       logfit = slope*logdylist + offset
+   #       fitfunc = np.exp(logfit)
+   #    except ValueError:
+   #       print("Infs/Nans encountered in fit, skipping")
+   #       slope = None
+   #       offset = None
+   #       fitfunc = None
+      
+   #    # record results in dictionary and plot
+   #    #label = attrs["operator"] + " : f = " + attrs["inp"]
+   #    #label = "FV::Div_a_Grad_perp(a, f)"
+   #    plot_data[label] = [dylist, l2norm, fitfunc, slope, offset, expected_slope]
+
+   # # plot the results
+   # try:
+   #    import matplotlib.pyplot as plt
+   #    ifig = 0
+   #    for key, variable_set in plot_data.items():
+   #       (xaxis, yaxis, fit, slope, offset, expected_slope) = variable_set
+   #       plt.figure()
+   #       plt.plot(xaxis, yaxis, "x-", label="$\\epsilon(\\mathcal{L}\\ast f)$: "+key)
+   #       plt.plot(xaxis, yaxis[0]*(xaxis/xaxis[0])**expected_slope, "x-", label="$\\propto \\Delta^{{{:.2f}}}$".format(expected_slope))
+   #       if not fit is None:
+   #             plt.plot(xaxis, fit, "x-", label="$e^{{{:.2f}}}\\Delta^{{{:.2f}}}$".format(offset,slope))
+   #       plt.xlabel("$\\Delta = 1/N_y$")
+   #       plt.title(key)
+   #       plt.legend()
+   #       if not fit is None:
+   #             plt.gca().set_yscale("log")
+   #             plt.gca().set_xscale("log")
+   #       else:
+   #             print("l2 error: ",yaxis)
+   #       plt.savefig(f"{base_test_dir}/fig_{ifig}.png")
+   #       if interactive_plots:
+   #           plt.show()
+   #       plt.close()
+   #       ifig+=1
+   # except:
+   # # Plotting could fail for any number of reasons, and the actual
+   # # error raised may depend on, among other things, the current
+   # # matplotlib backend, so catch everything
+   #    pass
+
+   # # test the convergence rates
+   # success = True
+   # output_message = ""
+   # for key, variable_set in plot_data.items():
+   #    this_test_success = True
+   #    (xaxis, yaxis, fit, slope, offset, expected_slope) = variable_set
+   #    # check slope of fit ~= 2
+   #    slope_min = 0.975*expected_slope
+   #    if not slope is None:
+   #       if slope < slope_min:
+   #             this_test_success = False
+   #    else: # or permit near-zero errors, but nothing larger
+   #       for error in yaxis:
+   #             if error > 1.0e-10:
+   #                this_test_success = False
+   #    # append test message and set global success variable
+   #    if this_test_success:
+   #       output_message += f"{key} convergence order {slope:.2f} > {slope_min:.2f} => Test passed \n"
+   #    else:
+   #       output_message += f"{key} convergence order {slope:.2f} < {slope_min:.2f} => Test failed \n"
+   #       success = False
+
+   # return success, output_message
+   return None

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -320,7 +320,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    # need guard cells in x (assume 2 here) and guard cells in y (assume 1)
    # no guard cells in z
    s = slice(1, 2), slice(2, -2), slice(1, -1), slice(None)
-
+   sxyz = slice(2, -2), slice(1, -1), slice(None)
+   sx = slice(2, -2)
+   sy = slice(1, -1)
+   sz = slice(None)
    # a dictionary of plot data, filled later on
    plot_data = dict()
 
@@ -337,7 +340,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
    
-   for varstring in ["ddt(Nd)", "ddt(Pd)"]:
+   for varstring in ["ddt(Nd)", "ddt(Pd)", "Nd", "Pd"]:
       label = varstring
       expected_slope = 2.0
       l2norm = []
@@ -346,10 +349,14 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
       for m in range(0,ntest):
          #print(varstring)
          numerical = collectvar(datasets, varstring, m)
-         error_values = (numerical)[s]
-         #print("values", error_values.values)
-         #print("data" , error_values.data)
-         #print("shape" , error_values.shape)
+         if label[0:3] == "ddt":
+            error_values = (numerical)[s]
+         else:
+            error_values = numerical[-1,sx,sy,sz] - numerical[0,sx,sy,sz]
+         # error_values = numerical[0,sx,sy,sz]
+         # print("values", error_values.values)
+         # print("data" , error_values.data)
+         # print("shape" , error_values.shape)
          thisl2 = np.sqrt(np.mean(error_values**2))
          #print("thisl2",thisl2)
          l2norm.append(thisl2)

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -252,12 +252,19 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    neutral_viscosity = test_input["neutral_viscosity"]
    evolve_momentum = test_input["evolve_momentum"]
    base_test_dir = test_input["test_dir"]
+   sub_test_dir = test_input["sub_test_dir"]
    interactive_plots = test_input["interactive_plots"]
    conservation_test = test_input["conservation_test"]
 
    # create directory 
    if not os.path.isdir(base_test_dir):
        os.system("mkdir "+base_test_dir)
+   # create sub-directory, if required
+   if not sub_test_dir is None:
+      base_test_dir = base_test_dir + "/" + sub_test_dir
+      if not os.path.isdir(base_test_dir):
+         os.system("mkdir "+base_test_dir)
+
    workdirs = []
    # make test for each resolution based on template file
    for i in range(0,ntest):

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -223,6 +223,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    # the number of points in the ith test is ngrid*i
    nnbase = test_input["ngrid"]
    # list of [name, symbolic string, expected convergence order]
+   nu_cfreq = test_input["collision_frequency"]
    Nd_string = test_input["Nd_string"]
    Pd_string = test_input["Pd_string"]
    source_Nd_string = test_input["source_Nd_string"]
@@ -290,6 +291,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    evolve_momentum = false
    precondition = true
    diagnose = true
+   rnn_override = {nu_cfreq}
+   flux_limit = -1.0
+   diffusion_limit = -1.0
+   lax_flux = false
    [Nd]
 
    function = {Nd_string}

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -223,8 +223,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    # the number of points in the ith test is ngrid*i
    nnbase = test_input["ngrid"]
    # list of [name, symbolic string, expected convergence order]
-   astr = test_input["a_string"]
-   fstr = test_input["f_string"]
+   Nd_string = test_input["Nd_string"]
+   Pd_string = test_input["Pd_string"]
+   source_Nd_string = test_input["source_Nd_string"]
+   source_Pd_string = test_input["source_Pd_string"]
    g11_str = test_input["g11_string"]
    g22_str = test_input["g22_string"]
    g33_str = test_input["g33_string"]
@@ -290,14 +292,16 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    diagnose = true
    [Nd]
 
-   function = 1 - 0.5*x^2
+   function = {Nd_string}
    bndry_core = neumann
    bndry_all = neumann
+   source = {source_Nd_string}
 
    [Pd]
-   function = 1 - 0.5*x^2
+   function = {Pd_string}
    bndry_core = neumann
    bndry_all = neumann
+   source = {source_Pd_string}
    """
          file.write(mesh_string.replace("**","^"))
 

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -234,6 +234,13 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    g12_str = test_input["g12_string"]
    g13_str = test_input["g13_string"]
    g23_str = test_input["g23_string"]
+   g_11_str = test_input["g_11_string"]
+   g_22_str = test_input["g_22_string"]
+   g_33_str = test_input["g_33_string"]
+   g_12_str = test_input["g_12_string"]
+   g_13_str = test_input["g_13_string"]
+   g_23_str = test_input["g_23_string"]
+   J_str = test_input["J_string"]
    neutral_conduction = test_input["neutral_conduction"]
    base_test_dir = test_input["test_dir"]
    interactive_plots = test_input["interactive_plots"]
@@ -278,6 +285,13 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    g12 = {g12_str}
    g23 = {g23_str}
    g13 = {g13_str}
+   g_11 = {g_11_str}
+   g_22 = {g_22_str}
+   g_33 = {g_33_str}
+   g_12 = {g_12_str}
+   g_23 = {g_23_str}
+   g_13 = {g_13_str}
+   J = {J_str}
    
    #################################################################
    # Neutrals

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -268,8 +268,8 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    dx = {ddx}
    ny = {nn}
    dy = {dd}
-   nz = {nn}
-   dz = {dd}
+   nz = {1}
+   dz = {1.0}
 
    g11 = {g11_str}
    g22 = {g22_str}

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -230,8 +230,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    nu_cfreq = test_input["collision_frequency"]
    Nd_string = test_input["Nd_string"]
    Pd_string = test_input["Pd_string"]
+   NVd_string = test_input["NVd_string"]
    source_Nd_string = test_input["source_Nd_string"]
    source_Pd_string = test_input["source_Pd_string"]
+   source_NVd_string = test_input["source_NVd_string"]
    g11_str = test_input["g11_string"]
    g22_str = test_input["g22_string"]
    g33_str = test_input["g33_string"]
@@ -245,7 +247,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    g_13_str = test_input["g_13_string"]
    g_23_str = test_input["g_23_string"]
    J_str = test_input["J_string"]
+   mass = test_input["mass"]
    neutral_conduction = test_input["neutral_conduction"]
+   neutral_viscosity = test_input["neutral_viscosity"]
+   evolve_momentum = test_input["evolve_momentum"]
    base_test_dir = test_input["test_dir"]
    interactive_plots = test_input["interactive_plots"]
    conservation_test = test_input["conservation_test"]
@@ -300,6 +305,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    
    Nd_src = {source_Nd_string}
    Pd_src = {source_Pd_string}
+   NVd_src = {source_NVd_string}
 
    #################################################################
    # Neutrals
@@ -307,11 +313,11 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    [d]
    type = neutral_mixed
 
-   AA = 2
+   AA = {mass}
 
    diagnose = true
    output_ddt = true
-   evolve_momentum = false
+   evolve_momentum = {evolve_momentum}
    precondition = true
    diagnose = true
    rnn_override = {nu_cfreq}
@@ -320,6 +326,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    lax_flux = false
    density_floor = 1.0e-15
    neutral_conduction = {neutral_conduction}
+   neutral_viscosity = {neutral_viscosity}
    normalise_sources = false
    [Nd]
 
@@ -329,6 +336,13 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    
    [Pd]
    function = {Pd_string}
+   bndry_core = neumann
+   bndry_all = neumann
+   """
+         if evolve_momentum:
+             mesh_string = mesh_string + f"""
+   [NVd]
+   function = {NVd_string}
    bndry_core = neumann
    bndry_all = neumann
    """
@@ -365,8 +379,11 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #   for key in keys:
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
-   
-   for varstring in ["ddt(Nd)", "ddt(Pd)"]: #, "Nd", "Pd"
+   function_list = ["ddt(Nd)", "ddt(Pd)"]
+   if evolve_momentum:
+       function_list.append("ddt(NVd)")
+
+   for varstring in function_list: #, "Nd", "Pd"
       label = varstring
       expected_slope = 2.0
       l2norm = []

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -3,6 +3,7 @@ import os
 from xbout import open_boutdataset
 import numpy as np
 from scipy.optimize import curve_fit
+from boututils.run_wrapper import launch
 
 def lin_func(x,b,a):
     return b*x + a
@@ -357,8 +358,11 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
          file.write(mesh_string.replace("**","^"))
 
       # run job on this input
-      print("../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt")
-      os.system("../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt")
+      print("mpirun -n 1 ../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt")
+      # Command to run
+      cmd = "../.././hermes-3 -d "+workdir+" > "+workdir+"/output.txt"
+      # Launch using MPI
+      s, out = launch(cmd, nproc=1, pipe=True)
 
    # now analyse the results of the test
    # this slice avoids including guard cells in the test

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -322,7 +322,8 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    # need to select last time point
    # need guard cells in x (assume 2 here) and guard cells in y (assume 1)
    # no guard cells in z
-   s = slice(1, 2), slice(2, -2), slice(1, -1), slice(None)
+   s = slice(None), slice(2, -2), slice(1, -1), slice(None)
+   #s = slice(1, 2), slice(2, -2), slice(1, -1), slice(None)
    sxyz = slice(2, -2), slice(1, -1), slice(None)
    sx = slice(2, -2)
    sy = slice(1, -1)
@@ -343,7 +344,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
    
-   for varstring in ["ddt(Nd)", "ddt(Pd)", "Nd", "Pd"]:
+   for varstring in ["ddt(Nd)", "ddt(Pd)"]:#, "Nd", "Pd"]:
       label = varstring
       expected_slope = 2.0
       l2norm = []

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -344,7 +344,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
    
-   for varstring in ["ddt(Nd)", "ddt(Pd)"]:#, "Nd", "Pd"]:
+   for varstring in ["ddt(Nd)", "ddt(Pd)", "Nd", "Pd"]:
       label = varstring
       expected_slope = 2.0
       l2norm = []
@@ -353,10 +353,10 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
       for m in range(0,ntest):
          #print(varstring)
          numerical = collectvar(datasets, varstring, m)
-         if label[0:3] == "ddt":
-            error_values = (numerical)[s]
-         else:
-            error_values = numerical[-1,sx,sy,sz] - numerical[0,sx,sy,sz]
+         #if label[0:3] == "ddt":
+         error_values = (numerical)[s]
+         #else:
+         #   error_values = numerical[-1,sx,sy,sz] - numerical[0,sx,sy,sz]
          # error_values = numerical[0,sx,sy,sz]
          # print("values", error_values.values)
          # print("data" , error_values.data)

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -255,6 +255,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    sub_test_dir = test_input["sub_test_dir"]
    interactive_plots = test_input["interactive_plots"]
    conservation_test = test_input["conservation_test"]
+   expected_convergence_order = test_input["expected_convergence_order"]
 
    # create directory 
    if not os.path.isdir(base_test_dir):
@@ -391,7 +392,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
        function_list.append("ddt(NVd)")
 
    for varstring in function_list:
-      expected_slope = 2.0
+      expected_slope = expected_convergence_order
       l2norm = []
       nylist = []
       dylist = []
@@ -484,27 +485,26 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    # matplotlib backend, so catch everything
       pass
 
-   # # test the convergence rates
-   # success = True
-   # output_message = ""
-   # for key, variable_set in plot_data.items():
-   #    this_test_success = True
-   #    (xaxis, yaxis, fit, slope, offset, expected_slope) = variable_set
-   #    # check slope of fit ~= 2
-   #    slope_min = 0.975*expected_slope
-   #    if not slope is None:
-   #       if slope < slope_min:
-   #             this_test_success = False
-   #    else: # or permit near-zero errors, but nothing larger
-   #       for error in yaxis:
-   #             if error > 1.0e-10:
-   #                this_test_success = False
-   #    # append test message and set global success variable
-   #    if this_test_success:
-   #       output_message += f"{key} convergence order {slope:.2f} > {slope_min:.2f} => Test passed \n"
-   #    else:
-   #       output_message += f"{key} convergence order {slope:.2f} < {slope_min:.2f} => Test failed \n"
-   #       success = False
+   # test the convergence rates
+   success = True
+   output_message = ""
+   for key, variable_set in plot_data.items():
+      this_test_success = True
+      (xaxis, yaxis, fit, slope, offset, expected_slope) = variable_set
+      # check slope of fit ~= 2
+      slope_min = 0.975*expected_slope
+      if not slope is None:
+         if slope < slope_min:
+               this_test_success = False
+      else: # or permit near-zero errors, but nothing larger
+         for error in yaxis:
+               if error > 1.0e-10:
+                  this_test_success = False
+      # append test message and set global success variable
+      if this_test_success:
+         output_message += f"{base_test_dir}: {key} convergence order {slope:.2f} > {slope_min:.2f} => Test passed \n"
+      else:
+         output_message += f"{base_test_dir}: {key} convergence order {slope:.2f} < {slope_min:.2f} => Test failed \n"
+         success = False
 
-   # return success, output_message
-   return None
+   return success, output_message

--- a/tests/mms/job_functions.py
+++ b/tests/mms/job_functions.py
@@ -293,6 +293,9 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    g_13 = {g_13_str}
    J = {J_str}
    
+   Nd_src = {source_Nd_string}
+   Pd_src = {source_Pd_string}
+
    #################################################################
    # Neutrals
 
@@ -312,18 +315,17 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    lax_flux = false
    density_floor = 1.0e-15
    neutral_conduction = {neutral_conduction}
+   normalise_sources = false
    [Nd]
 
    function = {Nd_string}
    bndry_core = neumann
    bndry_all = neumann
-   source = {source_Nd_string}
-
+   
    [Pd]
    function = {Pd_string}
    bndry_core = neumann
    bndry_all = neumann
-   source = {source_Pd_string}
    """
          file.write(mesh_string.replace("**","^"))
 
@@ -358,7 +360,7 @@ def run_neutral_mixed_manufactured_solutions_test(test_input):
    #      print(key)     
    # make a easy scan over the two operators, generalisation to N operators possible
    
-   for varstring in ["ddt(Nd)", "ddt(Pd)", "Nd", "Pd"]:
+   for varstring in ["ddt(Nd)", "ddt(Pd)"]: #, "Nd", "Pd"
       label = varstring
       expected_slope = 2.0
       l2norm = []

--- a/tests/mms/main.cxx
+++ b/tests/mms/main.cxx
@@ -45,6 +45,10 @@ const auto differential_operators_1_arg = {
                  [](const Field3D &f) {
                    return Div_par(f);
                  }},
+    nameandfunction1{"Grad_par(f)",
+                 [](const Field3D &f) {
+                   return Grad_par(f);
+                 }},
 };
 // List of tested operators of 2 arguments
 const auto differential_operators_2_arg = {

--- a/tests/mms/main.cxx
+++ b/tests/mms/main.cxx
@@ -6,6 +6,7 @@
 #include "bout/fv_ops.hxx"
 #include "bout/difops.hxx"
 #include "../include/div_ops.hxx"
+using ParLimiter = FV::Upwind;
 
 // Class used to store function of one argument
 // in operator list below
@@ -27,6 +28,12 @@ class nameandfunction3 {
 public:
   std::string name;
   std::function<Field3D(const Field3D&, const Field3D&, Field3D&)> func;
+};
+
+class nameandfunction3_mod {
+  public:
+    std::string name;
+    std::function<Field3D(const Field3D&, const Field3D&, const Field3D&)> func;
 };
 
 // Class used to store function of four arguments
@@ -62,6 +69,13 @@ const auto differential_operators_3_arg = {
   nameandfunction3{"Div_par_K_Grad_par_mod(a, f)",
                [](const Field3D &a, const Field3D &f, Field3D &flow_ylow) {
                  return Div_par_K_Grad_par_mod(a, f, flow_ylow, true);
+               }},
+};
+// List of tested operators of 3 arguments
+const auto differential_operators_3_arg_mod = {
+  nameandfunction3_mod{"FV::Div_par_fvv(f, v, wave_speed)",
+               [](const Field3D &f, const Field3D &v, const Field3D &wave_speed) {
+                 return FV::Div_par_fvv<ParLimiter>(f, v, wave_speed, true);
                }},
 };
 // List of tested operators of 4 arguments
@@ -116,6 +130,11 @@ int main(int argc, char** argv) {
   // diagnostic variables
   Field3D flow_xlow{mesh};
   Field3D flow_ylow{mesh};
+  // auxiliary variables
+  Field3D ones{mesh};
+  ones = 1.0;
+  Field3D zeros{mesh};
+  zeros = 0.0;
 
   for (int i = 0; i < n_operators; i++){
       std::string inputname = "differential_operator_name_"+std::to_string(i);
@@ -168,6 +187,20 @@ int main(int argc, char** argv) {
             dump[expectedname] = expected_result;
             // dump diagnostics
             dump[outname_flow_ylow] = flow_ylow;
+        }
+      }
+      for (const auto& difop: differential_operators_3_arg_mod) {
+        if (difop.name.compare(differential_operator_name) == 0){
+            // Get result of applying the named differential operator
+            Field3D result = difop.func(f, ones, zeros);
+            dump[outname] = result;
+            dump[outname].setAttributes({
+                  {"operator", difop.name},
+              });
+            // Get expected result from input file
+            Field3D expected_result{mesh};
+            mesh->get(expected_result, expectedname, 0.0, false);
+            dump[expectedname] = expected_result;
         }
       }
       for (const auto& difop: differential_operators_4_arg) {

--- a/tests/mms/main.cxx
+++ b/tests/mms/main.cxx
@@ -15,6 +15,12 @@ public:
   std::function<Field3D(const Field3D&, const Field3D&)> func;
 };
 
+class nameandfunction3 {
+public:
+  std::string name;
+  std::function<Field3D(const Field3D&, const Field3D&, Field3D&)> func;
+};
+
 // Class used to store function of four arguments
 // in operator list below. Second pair of arguments are
 // internal diagnostics to the function
@@ -31,6 +37,13 @@ const auto differential_operators_2_arg = {
                  [](const Field3D &a, const Field3D &f) {
                    return FV::Div_a_Grad_perp(a, f);
                  }},
+};
+// List of tested operators of 3 arguments
+const auto differential_operators_3_arg = {
+  nameandfunction3{"Div_par_K_Grad_par_mod(a, f)",
+               [](const Field3D &a, const Field3D &f, Field3D &flow_ylow) {
+                 return Div_par_K_Grad_par_mod(a, f, flow_ylow, true);
+               }},
 };
 // List of tested operators of 4 arguments
 const auto differential_operators_4_arg = {
@@ -108,6 +121,22 @@ int main(int argc, char** argv) {
               dump[expectedname] = expected_result;
           }
       }
+      for (const auto& difop: differential_operators_3_arg) {
+        if (difop.name.compare(differential_operator_name) == 0){
+            // Get result of applying the named differential operator
+            Field3D result = difop.func(a, f, flow_ylow);
+            dump[outname] = result;
+            dump[outname].setAttributes({
+                  {"operator", difop.name},
+              });
+            // Get expected result from input file
+            Field3D expected_result{mesh};
+            mesh->get(expected_result, expectedname, 0.0, false);
+            dump[expectedname] = expected_result;
+            // dump diagnostics
+            dump[outname_flow_ylow] = flow_ylow;
+        }
+      }
       for (const auto& difop: differential_operators_4_arg) {
         if (difop.name.compare(differential_operator_name) == 0){
             // Get result of applying the named differential operator
@@ -124,7 +153,7 @@ int main(int argc, char** argv) {
             dump[outname_flow_xlow] = flow_xlow;
             dump[outname_flow_ylow] = flow_ylow;
         }
-    }
+      }
   }
   //Field3D result = FV::Div_a_Grad_perp(a, f);
   //dump["result"] = result;

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -7,6 +7,7 @@ from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos, log
 
 conservation_test = False
+evolve_momentum = True
 # specify symbolic inputs
 # contravariant metric coeffs
 g11 = 1.1 + 0.16*x*cos(y)
@@ -15,7 +16,44 @@ g33 = 1.2 + 0.2*x*cos(y)
 g12 = 0.0
 g23 = 0.5 + 0.15*x*cos(y)
 g13 = 0.0
+# g11 = 1.0
+# g22 = 1.0
+# g33 = 1.0
+# g12 = 0.0
+# g23 = 0.0
+# g13 = 0.0
 g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
+
+
+pfac = 0.2
+nfac = 0.2
+# mass 
+AA = 2.0
+# collision frequency
+nu_cfreq = 1.0
+# Manufactured solutions
+Nn = 0.5 + nfac*(0.5 + x**3 - 1.5*x**2)*sin(y)
+Pn = 1.0 + pfac*(0.5 + x**3 - 1.5*x**2)*sin(2*y)
+if evolve_momentum:
+    # choose function that is both zero on boundary in x
+    # and has no derivative
+    NVn = (x**2 - 2*x**3 + x**4)*sin(y)
+    #NVn = 0.0 + x*(x-1)*cos(y)
+else:
+    NVn = 0.0
+
+# Derived quantities
+Vn = NVn/(Nn*AA)
+Tn = Pn/Nn
+logPn = log(Pn)
+Dn = (Tn/AA)/nu_cfreq
+Kn = (5.0/2.0)*Nn*Dn
+Etan = (2.0/5.0)*AA*Kn
+neutral_conduction = True
+neutral_viscosity = True
+
+# time evolution equations without sources
+# N.B. 
 # Div . ( a Grad_perp f )
 #div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( a Grad_par f)
@@ -25,44 +63,49 @@ g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, 
 # vec(b) . Grad f
 #grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
-dfac = 0.2
-# mass 
-AA = 2
-# collision frequency
-nu_cfreq = 1.0
-# Manufactured solutions
-Nn = 0.5 + dfac*(0.5 + x**3 - 1.5*x**2)*sin(y)
-Pn = 1.0 + dfac*(0.5 + x**3 - 1.5*x**2)*sin(2*y)
-NVn = 0.0
+ddt_Nn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
+            -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
+            )
 
-# Derived quantities
-Vn = NVn/(Nn*AA)
-Tn = Pn/Nn
-logPn = log(Pn)
-Dn = (Tn/AA)/nu_cfreq
-Kn = (5.0/2.0)*Nn*Dn
-neutral_conduction = True
-# time evolution equations without sources
-ddt_Nn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
-          -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
-          )
+ddt_Pn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn*Vn)
+            -(5.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
+            -(2.0/3.0)*Pn*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Vn)
+            )
 
-ddt_Pn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
-          -(5.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
-)
+ddt_NVn = ( - AA*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Vn)
+            + AA*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Dn, logPn)
+            - grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn)
+            )
+# if neutral conduction included in test
 if neutral_conduction:
-   ddt_Pn = (ddt_Pn +
-          +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
-          +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
-          )
+    ddt_Pn = (ddt_Pn +
+            +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+            +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+            )
+# if neutral viscosity included in test
+if neutral_viscosity:
+    viscosity_source = AA*(div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn)
+                     + div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn))
+    ddt_NVn = (ddt_NVn +
+                viscosity_source
+                )
+    ddt_Pn = (ddt_Pn - 
+               (2.0/3.0)*Vn*viscosity_source
+               )
 
 # Sources for steady state
 if conservation_test:
+    # we just want to make ddt and test conservation properties
+    # so no sources are required here
     source_Nn = 0.0
     source_Pn = 0.0
+    source_NVn = 0.0
 else:
+    # we want to cancel the numerically calculated ddt with an
+    # analytical source, so set the sources
     source_Nn = -ddt_Nn
     source_Pn = -ddt_Pn
+    source_NVn = -ddt_NVn
 
 test_input = {
     "ntest" : 3, 
@@ -81,11 +124,16 @@ test_input = {
     "g_13_string": str(g_13),
     "g_23_string": str(g_23),
     "J_string": str(J),
+    "mass" : AA,
     "Nd_string" : str(Nn),
     "Pd_string" : str(Pn),
+    "NVd_string" : str(NVn),
     "source_Nd_string" : str(source_Nn),
     "source_Pd_string" : str(source_Pn),
+    "source_NVd_string" : str(source_NVn),
     "neutral_conduction" : neutral_conduction,
+    "neutral_viscosity" : neutral_viscosity,
+    "evolve_momentum" : evolve_momentum,
     "test_dir" : "neutral_mixed",
     "interactive_plots" : True,
     "conservation_test" : conservation_test

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -6,7 +6,7 @@ from perpendicular_laplacian import div_par_f_symbolic, metric_coefficients
 from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos, log
 
-conservation_test = False
+conservation_test = True#False
 evolve_momentum = True
 # specify symbolic inputs
 # contravariant metric coeffs

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -4,7 +4,7 @@ from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
 from perpendicular_laplacian import div_par_f_symbolic
 from perpendicular_laplacian import grad_par_f_symbolic
-from sympy import sin, cos
+from sympy import sin, cos, log
 
 # specify symbolic inputs
 # contravariant metric coeffs
@@ -14,29 +14,55 @@ g33 = 1.2 + 0.2*x*cos(y)
 g12 = 0.0
 g23 = 0.5 + 0.15*x*cos(y)
 g13 = 0.0
-# f and a
-f = (x**2)*sin(y)*sin(z)
-a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
 # Div . ( a Grad_perp f )
-div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+#div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( a Grad_par f)
-div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+#div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( vec(b) f)
-div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+#div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 # vec(b) . Grad f
-grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+#grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+
+# mass 
+AA = 2
+# collision frequency
+nu_cfreq = 1.0
+# Manufactured solutions
+Nn = 0.5 + 0.1*(x**2)*sin(y)*sin(z)
+NVn = 0.0
+Vn = NVn/(Nn*AA)
+Pn = 1.0 + 0.5*(x**2)*sin(2*y)*sin(2*z)
+Tn = Pn/Nn
+logPn = log(Pn)
+Dn = nu_cfreq*Tn/AA
+Kn = (5.0/2.0)*Nn*Dn
+# time evolution equations without sources
+ddt_Nn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
+          -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
+          )
+
+ddt_Pn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
+          -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
+          +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+          +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+          )
+# Sources for steady state
+source_Nn = -ddt_Nn
+source_Pn = -ddt_Pn
 
 test_input = {
     "ntest" : 1, 
     "ngrid" : 20,
-    "a_string": str(a),
-    "f_string": str(f),
     "g11_string": str(g11),
     "g22_string": str(g22),
     "g33_string": str(g33),
     "g12_string": str(g12),
     "g13_string": str(g13),
     "g23_string": str(g23),
+    "Nd_string" : str(Nn),
+    "Pd_string" : str(Pn),
+    "source_Nd_string" : str(source_Nn),
+    "source_Pd_string" : str(source_Pn),
     "test_dir" : "neutral_mixed",
     "interactive_plots" : False
 }

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -14,6 +14,10 @@ from sympy import sin, cos, log
 # g12 = 0.0
 # g23 = 0.5 + 0.15*x*cos(y)
 # g13 = 0.0
+# we can safely specify the simplest metric
+# here knowing that the symbolic operators
+# are used in orthogonal_test.py and nonorthogonal_test.py
+# to test more complex metrics.
 g11 = 1.0
 g22 = 1.0
 g33 = 1.0
@@ -22,7 +26,10 @@ g23 = 0.0
 g13 = 0.0
 g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
 
-def neutral_mixed_equations(evolve_momentum=False, conservation_test=False, test_dir="neutral_mixed"):
+def neutral_mixed_equations(evolve_momentum=False, 
+                            conservation_test=False,
+                            # expected N in discretisation error ~ (grid_spacing)^N
+                            expected_convergence_order=2.0):
     pfac = 0.2
     nfac = 0.2
     # mass 
@@ -91,7 +98,10 @@ def neutral_mixed_equations(evolve_momentum=False, conservation_test=False, test
                 (2.0/3.0)*Vn*viscosity_source
                 )
 
-    # Sources for steady state
+    # Sources for steady state, set to exactly cancel
+    # the RHS operators if aiming to test the definition
+    # of the RHS, or set to zero if we just want to test
+    # that the RHS is conservative.
     if conservation_test:
         # we just want to make ddt and test conservation properties
         # so no sources are required here
@@ -132,18 +142,46 @@ def neutral_mixed_equations(evolve_momentum=False, conservation_test=False, test
         "neutral_conduction" : neutral_conduction,
         "neutral_viscosity" : neutral_viscosity,
         "evolve_momentum" : evolve_momentum,
-        "test_dir" : test_dir,
+        "test_dir" : "neutral_mixed",
         "sub_test_dir" : "evolve_momentum_"+str(evolve_momentum)+"_conservation_test_"+str(conservation_test),
-        "interactive_plots" : True,
+        "interactive_plots" : False,
         "conservation_test" : conservation_test,
+        "expected_convergence_order" : expected_convergence_order,
     }
     return test_input
 
-test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=False)
-run_neutral_mixed_manufactured_solutions_test(test_input)
-test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=True)
-run_neutral_mixed_manufactured_solutions_test(test_input)
-test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=False)
-run_neutral_mixed_manufactured_solutions_test(test_input)
-test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=True)
-run_neutral_mixed_manufactured_solutions_test(test_input)
+global_success = True
+
+test_input = neutral_mixed_equations(evolve_momentum=False,
+                                    conservation_test=False,
+                                    expected_convergence_order=2.0)
+success, output_message_0 = run_neutral_mixed_manufactured_solutions_test(test_input)
+global_success = success and global_success
+
+test_input = neutral_mixed_equations(evolve_momentum=False,
+                                    conservation_test=True,
+                                    expected_convergence_order=2.0)
+success, output_message_1 = run_neutral_mixed_manufactured_solutions_test(test_input)
+global_success = success and global_success
+
+test_input = neutral_mixed_equations(evolve_momentum=True,
+                                    conservation_test=False,
+                                    expected_convergence_order=1.0)
+success, output_message_2 = run_neutral_mixed_manufactured_solutions_test(test_input)
+global_success = success and global_success
+
+test_input = neutral_mixed_equations(evolve_momentum=True,
+                                    conservation_test=True,
+                                    expected_convergence_order=0.8)
+success, output_message_3 = run_neutral_mixed_manufactured_solutions_test(test_input)
+global_success = success and global_success
+
+print(output_message_0)
+print(output_message_1)
+print(output_message_2)
+print(output_message_3)
+
+if global_success:
+    exit(0)
+else:
+    exit(1)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -6,6 +6,7 @@ from perpendicular_laplacian import div_par_f_symbolic, metric_coefficients
 from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos, log
 
+conservation_test = False
 # specify symbolic inputs
 # contravariant metric coeffs
 g11 = 1.1 + 0.16*x*cos(y)
@@ -54,9 +55,14 @@ if neutral_conduction:
           +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
           +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
           )
+
 # Sources for steady state
-source_Nn = -ddt_Nn
-source_Pn = -ddt_Pn
+if conservation_test:
+    source_Nn = 0.0
+    source_Pn = 0.0
+else:
+    source_Nn = -ddt_Nn
+    source_Pn = -ddt_Pn
 
 test_input = {
     "ntest" : 3, 
@@ -81,7 +87,8 @@ test_input = {
     "source_Pd_string" : str(source_Pn),
     "neutral_conduction" : neutral_conduction,
     "test_dir" : "neutral_mixed",
-    "interactive_plots" : True
+    "interactive_plots" : True,
+    "conservation_test" : conservation_test
 }
 
 run_neutral_mixed_manufactured_solutions_test(test_input)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -24,21 +24,23 @@ g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, 
 # vec(b) . Grad f
 #grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
+dfac = 0.2
 # mass 
 AA = 2
 # collision frequency
 nu_cfreq = 1.0
 # Manufactured solutions
-Nn = 0.5 + x #0.1*(x**2)*sin(y) #*sin(z)
+Nn = 0.5 + dfac*(0.5 + x**3 - 1.5*x**2)*sin(y)
+Pn = 1.0 + dfac*(0.5 + x**3 - 1.5*x**2)*sin(2*y)
 NVn = 0.0
+
+# Derived quantities
 Vn = NVn/(Nn*AA)
-Pn = 1.0 + x**2 #0.5*(x**2)*sin(2*y) #*sin(2*z)
 Tn = Pn/Nn
 logPn = log(Pn)
-print(logPn)
 Dn = (Tn/AA)/nu_cfreq
 Kn = (5.0/2.0)*Nn*Dn
-neutral_conduction = False
+neutral_conduction = True
 # time evolution equations without sources
 ddt_Nn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
           -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -26,7 +26,7 @@ g13 = 0.0
 # mass 
 AA = 2
 # collision frequency
-nu_cfreq = 1.0
+nu_cfreq = 10.0
 # Manufactured solutions
 Nn = 0.5 + 0.1*(x**2)*sin(y)*sin(z)
 NVn = 0.0
@@ -34,7 +34,7 @@ Vn = NVn/(Nn*AA)
 Pn = 1.0 + 0.5*(x**2)*sin(2*y)*sin(2*z)
 Tn = Pn/Nn
 logPn = log(Pn)
-Dn = nu_cfreq*Tn/AA
+Dn = (Tn/AA)/nu_cfreq
 Kn = (5.0/2.0)*Nn*Dn
 # time evolution equations without sources
 ddt_Nn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
@@ -53,6 +53,7 @@ source_Pn = -ddt_Pn
 test_input = {
     "ntest" : 3, 
     "ngrid" : 20,
+    "collision_frequency" : nu_cfreq,
     "g11_string": str(g11),
     "g22_string": str(g22),
     "g33_string": str(g33),

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -51,8 +51,8 @@ source_Nn = -ddt_Nn
 source_Pn = -ddt_Pn
 
 test_input = {
-    "ntest" : 1, 
-    "ngrid" : 20,
+    "ntest" : 3, 
+    "ngrid" : 5,
     "g11_string": str(g11),
     "g22_string": str(g22),
     "g33_string": str(g33),
@@ -64,7 +64,7 @@ test_input = {
     "source_Nd_string" : str(source_Nn),
     "source_Pd_string" : str(source_Pn),
     "test_dir" : "neutral_mixed",
-    "interactive_plots" : False
+    "interactive_plots" : True
 }
 
 run_neutral_mixed_manufactured_solutions_test(test_input)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from job_functions import run_neutral_mixed_manufactured_solutions_test
+from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
+from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
+from perpendicular_laplacian import div_par_f_symbolic
+from perpendicular_laplacian import grad_par_f_symbolic
+from sympy import sin, cos
+
+# specify symbolic inputs
+# contravariant metric coeffs
+g11 = 1.1 + 0.16*x*cos(y)
+g22 = 0.9 + 0.09*x*cos(y)
+g33 = 1.2 + 0.2*x*cos(y)
+g12 = 0.0
+g23 = 0.5 + 0.15*x*cos(y)
+g13 = 0.0
+# f and a
+f = (x**2)*sin(y)*sin(z)
+a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
+# Div . ( a Grad_perp f )
+div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( a Grad_par f)
+div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( vec(b) f)
+div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+# vec(b) . Grad f
+grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+
+test_input = {
+    "ntest" : 1, 
+    "ngrid" : 20,
+    "a_string": str(a),
+    "f_string": str(f),
+    "g11_string": str(g11),
+    "g22_string": str(g22),
+    "g33_string": str(g33),
+    "g12_string": str(g12),
+    "g13_string": str(g13),
+    "g23_string": str(g23),
+    "test_dir" : "neutral_mixed",
+    "interactive_plots" : False
+}
+
+run_neutral_mixed_manufactured_solutions_test(test_input)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -6,8 +6,6 @@ from perpendicular_laplacian import div_par_f_symbolic, metric_coefficients
 from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos, log
 
-conservation_test = True#False
-evolve_momentum = True
 # specify symbolic inputs
 # contravariant metric coeffs
 g11 = 1.1 + 0.16*x*cos(y)
@@ -24,119 +22,127 @@ g13 = 0.0
 # g13 = 0.0
 g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
 
+def neutral_mixed_equations(evolve_momentum=False, conservation_test=False):
+    pfac = 0.2
+    nfac = 0.2
+    # mass 
+    AA = 2.0
+    # collision frequency
+    nu_cfreq = 1.0
+    # Manufactured solutions
+    Nn = 0.5 + nfac*(0.5 + x**3 - 1.5*x**2)*sin(y)
+    Pn = 1.0 + pfac*(0.5 + x**3 - 1.5*x**2)*sin(2*y)
+    if evolve_momentum:
+        # choose function that is both zero on boundary in x
+        # and has no derivative
+        NVn = (x**2 - 2*x**3 + x**4)*sin(y)
+        #NVn = 0.0 + x*(x-1)*cos(y)
+    else:
+        NVn = 0.0
 
-pfac = 0.2
-nfac = 0.2
-# mass 
-AA = 2.0
-# collision frequency
-nu_cfreq = 1.0
-# Manufactured solutions
-Nn = 0.5 + nfac*(0.5 + x**3 - 1.5*x**2)*sin(y)
-Pn = 1.0 + pfac*(0.5 + x**3 - 1.5*x**2)*sin(2*y)
-if evolve_momentum:
-    # choose function that is both zero on boundary in x
-    # and has no derivative
-    NVn = (x**2 - 2*x**3 + x**4)*sin(y)
-    #NVn = 0.0 + x*(x-1)*cos(y)
-else:
-    NVn = 0.0
+    # Derived quantities
+    Vn = NVn/(Nn*AA)
+    Tn = Pn/Nn
+    logPn = log(Pn)
+    Dn = (Tn/AA)/nu_cfreq
+    Kn = (5.0/2.0)*Nn*Dn
+    Etan = (2.0/5.0)*AA*Kn
+    neutral_conduction = True
+    neutral_viscosity = True
 
-# Derived quantities
-Vn = NVn/(Nn*AA)
-Tn = Pn/Nn
-logPn = log(Pn)
-Dn = (Tn/AA)/nu_cfreq
-Kn = (5.0/2.0)*Nn*Dn
-Etan = (2.0/5.0)*AA*Kn
-neutral_conduction = True
-neutral_viscosity = True
+    # time evolution equations without sources
+    # N.B. 
+    # Div . ( a Grad_perp f )
+    #div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+    # Div . ( a Grad_par f)
+    #div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+    # Div . ( vec(b) f)
+    #div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+    # vec(b) . Grad f
+    #grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
-# time evolution equations without sources
-# N.B. 
-# Div . ( a Grad_perp f )
-#div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
-# Div . ( a Grad_par f)
-#div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
-# Div . ( vec(b) f)
-#div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
-# vec(b) . Grad f
-#grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
-
-ddt_Nn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
-            -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
-            )
-
-ddt_Pn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn*Vn)
-            -(5.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
-            -(2.0/3.0)*Pn*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Vn)
-            )
-
-ddt_NVn = ( - AA*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Vn)
-            + AA*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Dn, logPn)
-            - grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn)
-            )
-# if neutral conduction included in test
-if neutral_conduction:
-    ddt_Pn = (ddt_Pn +
-            +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
-            +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
-            )
-# if neutral viscosity included in test
-if neutral_viscosity:
-    viscosity_source = AA*(div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn)
-                     + div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn))
-    ddt_NVn = (ddt_NVn +
-                viscosity_source
+    ddt_Nn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
+                -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
                 )
-    ddt_Pn = (ddt_Pn - 
-               (2.0/3.0)*Vn*viscosity_source
-               )
 
-# Sources for steady state
-if conservation_test:
-    # we just want to make ddt and test conservation properties
-    # so no sources are required here
-    source_Nn = 0.0
-    source_Pn = 0.0
-    source_NVn = 0.0
-else:
-    # we want to cancel the numerically calculated ddt with an
-    # analytical source, so set the sources
-    source_Nn = -ddt_Nn
-    source_Pn = -ddt_Pn
-    source_NVn = -ddt_NVn
+    ddt_Pn = (  -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn*Vn)
+                -(5.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
+                -(2.0/3.0)*Pn*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Vn)
+                )
 
-test_input = {
-    "ntest" : 3, 
-    "ngrid" : 10,
-    "collision_frequency" : nu_cfreq,
-    "g11_string": str(g11),
-    "g22_string": str(g22),
-    "g33_string": str(g33),
-    "g12_string": str(g12),
-    "g13_string": str(g13),
-    "g23_string": str(g23),
-    "g_11_string": str(g_11),
-    "g_22_string": str(g_22),
-    "g_33_string": str(g_33),
-    "g_12_string": str(g_12),
-    "g_13_string": str(g_13),
-    "g_23_string": str(g_23),
-    "J_string": str(J),
-    "mass" : AA,
-    "Nd_string" : str(Nn),
-    "Pd_string" : str(Pn),
-    "NVd_string" : str(NVn),
-    "source_Nd_string" : str(source_Nn),
-    "source_Pd_string" : str(source_Pn),
-    "source_NVd_string" : str(source_NVn),
-    "neutral_conduction" : neutral_conduction,
-    "neutral_viscosity" : neutral_viscosity,
-    "evolve_momentum" : evolve_momentum,
-    "test_dir" : "neutral_mixed",
-    "interactive_plots" : True,
-    "conservation_test" : conservation_test
-}
+    ddt_NVn = ( - AA*div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Vn)
+                + AA*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn*Dn, logPn)
+                - grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Pn)
+                )
+    # if neutral conduction included in test
+    if neutral_conduction:
+        ddt_Pn = (ddt_Pn +
+                +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+                +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
+                )
+    # if neutral viscosity included in test
+    if neutral_viscosity:
+        viscosity_source = AA*(div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn)
+                        + div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Etan, Vn))
+        ddt_NVn = (ddt_NVn +
+                    viscosity_source
+                    )
+        ddt_Pn = (ddt_Pn - 
+                (2.0/3.0)*Vn*viscosity_source
+                )
 
+    # Sources for steady state
+    if conservation_test:
+        # we just want to make ddt and test conservation properties
+        # so no sources are required here
+        source_Nn = 0.0
+        source_Pn = 0.0
+        source_NVn = 0.0
+    else:
+        # we want to cancel the numerically calculated ddt with an
+        # analytical source, so set the sources
+        source_Nn = -ddt_Nn
+        source_Pn = -ddt_Pn
+        source_NVn = -ddt_NVn
+
+    test_input = {
+        "ntest" : 3, 
+        "ngrid" : 10,
+        "collision_frequency" : nu_cfreq,
+        "g11_string": str(g11),
+        "g22_string": str(g22),
+        "g33_string": str(g33),
+        "g12_string": str(g12),
+        "g13_string": str(g13),
+        "g23_string": str(g23),
+        "g_11_string": str(g_11),
+        "g_22_string": str(g_22),
+        "g_33_string": str(g_33),
+        "g_12_string": str(g_12),
+        "g_13_string": str(g_13),
+        "g_23_string": str(g_23),
+        "J_string": str(J),
+        "mass" : AA,
+        "Nd_string" : str(Nn),
+        "Pd_string" : str(Pn),
+        "NVd_string" : str(NVn),
+        "source_Nd_string" : str(source_Nn),
+        "source_Pd_string" : str(source_Pn),
+        "source_NVd_string" : str(source_NVn),
+        "neutral_conduction" : neutral_conduction,
+        "neutral_viscosity" : neutral_viscosity,
+        "evolve_momentum" : evolve_momentum,
+        "test_dir" : "neutral_mixed",
+        "interactive_plots" : True,
+        "conservation_test" : conservation_test
+    }
+    return test_input
+
+#test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=False)
+#run_neutral_mixed_manufactured_solutions_test(test_input)
+#test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=True)
+#run_neutral_mixed_manufactured_solutions_test(test_input)
+#test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=False)
+#run_neutral_mixed_manufactured_solutions_test(test_input)
+test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=True)
 run_neutral_mixed_manufactured_solutions_test(test_input)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -52,7 +52,7 @@ source_Pn = -ddt_Pn
 
 test_input = {
     "ntest" : 3, 
-    "ngrid" : 5,
+    "ngrid" : 20,
     "g11_string": str(g11),
     "g22_string": str(g22),
     "g33_string": str(g33),

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -8,21 +8,21 @@ from sympy import sin, cos, log
 
 # specify symbolic inputs
 # contravariant metric coeffs
-g11 = 1.1 + 0.16*x*cos(y)
-g22 = 0.9 + 0.09*x*cos(y)
-g33 = 1.2 + 0.2*x*cos(y)
-g12 = 0.0
-g23 = 0.5 + 0.15*x*cos(y)
-g13 = 0.0
-# g11 = 1.0
-# g22 = 1.0
-# g33 = 1.0
+# g11 = 1.1 + 0.16*x*cos(y)
+# g22 = 0.9 + 0.09*x*cos(y)
+# g33 = 1.2 + 0.2*x*cos(y)
 # g12 = 0.0
-# g23 = 0.0
+# g23 = 0.5 + 0.15*x*cos(y)
 # g13 = 0.0
+g11 = 1.0
+g22 = 1.0
+g33 = 1.0
+g12 = 0.0
+g23 = 0.0
+g13 = 0.0
 g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
 
-def neutral_mixed_equations(evolve_momentum=False, conservation_test=False):
+def neutral_mixed_equations(evolve_momentum=False, conservation_test=False, test_dir="neutral_mixed"):
     pfac = 0.2
     nfac = 0.2
     # mass 
@@ -132,17 +132,18 @@ def neutral_mixed_equations(evolve_momentum=False, conservation_test=False):
         "neutral_conduction" : neutral_conduction,
         "neutral_viscosity" : neutral_viscosity,
         "evolve_momentum" : evolve_momentum,
-        "test_dir" : "neutral_mixed",
+        "test_dir" : test_dir,
+        "sub_test_dir" : "evolve_momentum_"+str(evolve_momentum)+"_conservation_test_"+str(conservation_test),
         "interactive_plots" : True,
-        "conservation_test" : conservation_test
+        "conservation_test" : conservation_test,
     }
     return test_input
 
-#test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=False)
-#run_neutral_mixed_manufactured_solutions_test(test_input)
-#test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=True)
-#run_neutral_mixed_manufactured_solutions_test(test_input)
-#test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=False)
-#run_neutral_mixed_manufactured_solutions_test(test_input)
+test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=False)
+run_neutral_mixed_manufactured_solutions_test(test_input)
+test_input = neutral_mixed_equations(evolve_momentum=False,conservation_test=True)
+run_neutral_mixed_manufactured_solutions_test(test_input)
+test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=False)
+run_neutral_mixed_manufactured_solutions_test(test_input)
 test_input = neutral_mixed_equations(evolve_momentum=True,conservation_test=True)
 run_neutral_mixed_manufactured_solutions_test(test_input)

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -2,7 +2,7 @@
 from job_functions import run_neutral_mixed_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
-from perpendicular_laplacian import div_par_f_symbolic
+from perpendicular_laplacian import div_par_f_symbolic, metric_coefficients
 from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos, log
 
@@ -14,6 +14,7 @@ g33 = 1.2 + 0.2*x*cos(y)
 g12 = 0.0
 g23 = 0.5 + 0.15*x*cos(y)
 g13 = 0.0
+g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
 # Div . ( a Grad_perp f )
 #div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( a Grad_par f)
@@ -28,12 +29,13 @@ AA = 2
 # collision frequency
 nu_cfreq = 1.0
 # Manufactured solutions
-Nn = 0.5 + 0.1*(x**2)*sin(y) #*sin(z)
+Nn = 0.5 + x #0.1*(x**2)*sin(y) #*sin(z)
 NVn = 0.0
 Vn = NVn/(Nn*AA)
-Pn = 1.0 + 0.5*(x**2)*sin(2*y) #*sin(2*z)
+Pn = 1.0 + x**2 #0.5*(x**2)*sin(2*y) #*sin(2*z)
 Tn = Pn/Nn
 logPn = log(Pn)
+print(logPn)
 Dn = (Tn/AA)/nu_cfreq
 Kn = (5.0/2.0)*Nn*Dn
 neutral_conduction = False
@@ -56,7 +58,7 @@ source_Pn = -ddt_Pn
 
 test_input = {
     "ntest" : 3, 
-    "ngrid" : 20,
+    "ngrid" : 10,
     "collision_frequency" : nu_cfreq,
     "g11_string": str(g11),
     "g22_string": str(g22),
@@ -64,6 +66,13 @@ test_input = {
     "g12_string": str(g12),
     "g13_string": str(g13),
     "g23_string": str(g23),
+    "g_11_string": str(g_11),
+    "g_22_string": str(g_22),
+    "g_33_string": str(g_33),
+    "g_12_string": str(g_12),
+    "g_13_string": str(g_13),
+    "g_23_string": str(g_23),
+    "J_string": str(J),
     "Nd_string" : str(Nn),
     "Pd_string" : str(Pn),
     "source_Nd_string" : str(source_Nn),

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -26,7 +26,7 @@ g13 = 0.0
 # mass 
 AA = 2
 # collision frequency
-nu_cfreq = 10.0
+nu_cfreq = 1.0
 # Manufactured solutions
 Nn = 0.5 + 0.1*(x**2)*sin(y) #*sin(z)
 NVn = 0.0
@@ -36,13 +36,17 @@ Tn = Pn/Nn
 logPn = log(Pn)
 Dn = (Tn/AA)/nu_cfreq
 Kn = (5.0/2.0)*Nn*Dn
+neutral_conduction = False
 # time evolution equations without sources
 ddt_Nn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
           -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Nn, logPn)
           )
 
 ddt_Pn = (# -div_par_f_symbolic(g11, g12, g13, g22, g23, g33, Nn*Vn)
-          -div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
+          -(5.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, -Dn*Pn, logPn)
+)
+if neutral_conduction:
+   ddt_Pn = (ddt_Pn +
           +(2.0/3.0)*div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
           +(2.0/3.0)*div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, Kn, Tn)
           )
@@ -64,6 +68,7 @@ test_input = {
     "Pd_string" : str(Pn),
     "source_Nd_string" : str(source_Nn),
     "source_Pd_string" : str(source_Pn),
+    "neutral_conduction" : neutral_conduction,
     "test_dir" : "neutral_mixed",
     "interactive_plots" : True
 }

--- a/tests/mms/neutral_mixed_ddt_test.py
+++ b/tests/mms/neutral_mixed_ddt_test.py
@@ -28,10 +28,10 @@ AA = 2
 # collision frequency
 nu_cfreq = 10.0
 # Manufactured solutions
-Nn = 0.5 + 0.1*(x**2)*sin(y)*sin(z)
+Nn = 0.5 + 0.1*(x**2)*sin(y) #*sin(z)
 NVn = 0.0
 Vn = NVn/(Nn*AA)
-Pn = 1.0 + 0.5*(x**2)*sin(2*y)*sin(2*z)
+Pn = 1.0 + 0.5*(x**2)*sin(2*y) #*sin(2*z)
 Tn = Pn/Nn
 logPn = log(Pn)
 Dn = (Tn/AA)/nu_cfreq

--- a/tests/mms/nonorthogonal_test.py
+++ b/tests/mms/nonorthogonal_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
+from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -16,11 +17,14 @@ f = (x**2)*sin(y)*sin(z)
 a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
 # Div . ( a Grad_perp f )
 div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( a Grad_par f )
+div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 
 test_input = {
     "ntest" : 3, 
     "ngrid" : 20,
-    "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],],
+    "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/nonorthogonal_test.py
+++ b/tests/mms/nonorthogonal_test.py
@@ -29,10 +29,12 @@ grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 test_input = {
     "ntest" : 3, 
     "ngrid" : 20,
-    "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
-                                   ["Div_par(f)", str(div_par_f)],
-                                   ["Grad_par(f)", str(grad_par_f)],
+    # list of list of ["name", symbolic function, expected convergence order]
+    "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f), 2],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f), 2],
+                                   ["Div_par(f)", str(div_par_f), 2],
+                                   ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f), 1],
+                                   ["Grad_par(f)", str(grad_par_f), 2],
                                    ],
     "a_string": str(a),
     "f_string": str(f),

--- a/tests/mms/nonorthogonal_test.py
+++ b/tests/mms/nonorthogonal_test.py
@@ -3,6 +3,7 @@ from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
 from perpendicular_laplacian import div_par_f_symbolic
+from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -22,13 +23,17 @@ div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, 
 div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( vec(b) f)
 div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+# vec(b) . Grad f
+grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
     "ntest" : 3, 
     "ngrid" : 20,
     "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
-                                   ["Div_par(f)", str(div_par_f)],],
+                                   ["Div_par(f)", str(div_par_f)],
+                                   ["Grad_par(f)", str(grad_par_f)],
+                                   ],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/nonorthogonal_test.py
+++ b/tests/mms/nonorthogonal_test.py
@@ -2,6 +2,7 @@
 from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
+from perpendicular_laplacian import div_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -19,12 +20,15 @@ a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
 div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( a Grad_par f )
 div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( vec(b) f)
+div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
     "ntest" : 3, 
     "ngrid" : 20,
     "differential_operator_list": [["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
+                                   ["Div_par(f)", str(div_par_f)],],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/nonorthogonal_test.py
+++ b/tests/mms/nonorthogonal_test.py
@@ -34,6 +34,7 @@ test_input = {
                                    ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f), 2],
                                    ["Div_par(f)", str(div_par_f), 2],
                                    ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f), 1],
+                                   ["FV::Div_par_mod(f, v, wave_speed)", str(div_par_f), 1],
                                    ["Grad_par(f)", str(grad_par_f), 2],
                                    ],
     "a_string": str(a),

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -27,15 +27,16 @@ div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
-    "ntest" : 5, 
+    "ntest" : 3, 
     "ngrid" : 20,
-    "differential_operator_list": [["FV::Div_a_Grad_perp(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
-                                   ["Div_par(f)", str(div_par_f)],
-                                   ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f)],
-                                   ["Grad_par(f)", str(grad_par_f)],
+    # list of list of ["name", symbolic function, expected convergence order]
+    "differential_operator_list": [["FV::Div_a_Grad_perp(a, f)", str(div_a_grad_perp_f), 2],
+                                   ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f), 2],
+                                   ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f), 2],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f), 2],
+                                   ["Div_par(f)", str(div_par_f), 2],
+                                   ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f), 1],
+                                   ["Grad_par(f)", str(grad_par_f), 2],
                                    ],
     "a_string": str(a),
     "f_string": str(f),
@@ -46,7 +47,7 @@ test_input = {
     "g13_string": str(g13),
     "g23_string": str(g23),
     "test_dir" : "orthogonal",
-    "interactive_plots" : True
+    "interactive_plots" : False
 }
 
 success, output_message = run_manufactured_solutions_test(test_input)

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -36,6 +36,7 @@ test_input = {
                                    ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f), 2],
                                    ["Div_par(f)", str(div_par_f), 2],
                                    ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f), 1],
+                                   ["FV::Div_par_mod(f, v, wave_speed)", str(div_par_f), 1],
                                    ["Grad_par(f)", str(grad_par_f), 2],
                                    ],
     "a_string": str(a),

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -2,6 +2,7 @@
 from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
+from perpendicular_laplacian import div_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -19,6 +20,8 @@ a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
 div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( a Grad_par f)
 div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( vec(b) f)
+div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
     "ntest" : 3, 
@@ -26,7 +29,8 @@ test_input = {
     "differential_operator_list": [["FV::Div_a_Grad_perp(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f)],
-                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
+                                   ["Div_par(f)", str(div_par_f)],],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
+from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -16,6 +17,8 @@ f = (x**2)*sin(y)*sin(z)
 a = 1.0 + 0.1*x**3*sin(2*y)*sin(2*z)
 # Div . ( a Grad_perp f )
 div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
+# Div . ( a Grad_par f)
+div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 
 test_input = {
     "ntest" : 3, 
@@ -23,7 +26,7 @@ test_input = {
     "differential_operator_list": [["FV::Div_a_Grad_perp(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f)],
-                                   ],
+                                   ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -3,6 +3,7 @@ from job_functions import run_manufactured_solutions_test
 from perpendicular_laplacian import x, y, z, div_a_grad_perp_f_symbolic
 from perpendicular_laplacian import div_par_k_grad_par_f_symbolic
 from perpendicular_laplacian import div_par_f_symbolic
+from perpendicular_laplacian import grad_par_f_symbolic
 from sympy import sin, cos
 
 # specify symbolic inputs
@@ -22,6 +23,8 @@ div_a_grad_perp_f = div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, 
 div_par_k_grad_par_f = div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f)
 # Div . ( vec(b) f)
 div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
+# vec(b) . Grad f
+grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
     "ntest" : 3, 
@@ -30,7 +33,9 @@ test_input = {
                                    ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
-                                   ["Div_par(f)", str(div_par_f)],],
+                                   ["Div_par(f)", str(div_par_f)],
+                                   ["Grad_par(f)", str(grad_par_f)],
+                                   ],
     "a_string": str(a),
     "f_string": str(f),
     "g11_string": str(g11),

--- a/tests/mms/orthogonal_test.py
+++ b/tests/mms/orthogonal_test.py
@@ -27,13 +27,14 @@ div_par_f = div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 grad_par_f = grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f)
 
 test_input = {
-    "ntest" : 3, 
+    "ntest" : 5, 
     "ngrid" : 20,
     "differential_operator_list": [["FV::Div_a_Grad_perp(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_nonorthog(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_a_Grad_perp_flows(a, f)", str(div_a_grad_perp_f)],
                                    ["Div_par_K_Grad_par_mod(a, f)", str(div_par_k_grad_par_f)],
                                    ["Div_par(f)", str(div_par_f)],
+                                   ["FV::Div_par_fvv(f, v, wave_speed)", str(div_par_f)],
                                    ["Grad_par(f)", str(grad_par_f)],
                                    ],
     "a_string": str(a),
@@ -45,7 +46,7 @@ test_input = {
     "g13_string": str(g13),
     "g23_string": str(g23),
     "test_dir" : "orthogonal",
-    "interactive_plots" : False
+    "interactive_plots" : True
 }
 
 success, output_message = run_manufactured_solutions_test(test_input)

--- a/tests/mms/perpendicular_laplacian.py
+++ b/tests/mms/perpendicular_laplacian.py
@@ -57,3 +57,10 @@ def div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
    k_grad_par_f = a*J*dfdy/g_22
    div_par_k_grad_par_f = (1/J)*(diff(k_grad_par_f,y))
    return div_par_k_grad_par_f
+
+def div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f):
+   g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
+   f_over_sqrt_g_22 = f/sqrt(g_22)
+   # should multiply also by sigma_Bpol here, but sigma_Bpol seems absent from BOUT-dev/src/mesh/difops.cxx
+   div_par_f = (1/J)*diff(J*f_over_sqrt_g_22,y)
+   return div_par_f

--- a/tests/mms/perpendicular_laplacian.py
+++ b/tests/mms/perpendicular_laplacian.py
@@ -64,3 +64,9 @@ def div_par_f_symbolic(g11, g12, g13, g22, g23, g33, f):
    # should multiply also by sigma_Bpol here, but sigma_Bpol seems absent from BOUT-dev/src/mesh/difops.cxx
    div_par_f = (1/J)*diff(J*f_over_sqrt_g_22,y)
    return div_par_f
+
+def grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, f):
+   g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
+   # should multiply also by sigma_Bpol here, but sigma_Bpol seems absent from BOUT-dev/src/mesh/difops.cxx
+   grad_par_f = (1/sqrt(g_22))*diff(f,y)
+   return grad_par_f

--- a/tests/mms/perpendicular_laplacian.py
+++ b/tests/mms/perpendicular_laplacian.py
@@ -7,10 +7,7 @@ x = symbols('x')
 y = symbols('y')
 z = symbols('z')
 
-# Div . ( a Grad_perp f )
-# see notes for formulae
-# https://bout-dev.readthedocs.io/en/stable/user_docs/coordinates.html#the-perpendicular-laplacian-in-divergence-form
-def div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
+def metric_coefficients(g11, g12, g13, g22, g23, g33):
    gup = Matrix(3,3,[g11,g12,g13,g12,g22,g23,g13,g23,g33])
    gdown = gup.inv()
    g_11 = gdown[0,0]
@@ -23,6 +20,13 @@ def div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
    detgup = gup.det()
    #detgup = g11*g22*g33 - g11*g23*g23 - g12*g12*g33 + g12*g13*g23 - g13*g13*g22 + g13*g12*g23
    J = 1/sqrt(detgup)
+   return g_11, g_12, g_13, g_22, g_23, g_33, J
+
+# Div . ( a Grad_perp f )
+# see notes for formulae
+# https://bout-dev.readthedocs.io/en/stable/user_docs/coordinates.html#the-perpendicular-laplacian-in-divergence-form
+def div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
+   g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
    #print("f(x,y,z) = ",f)
    #print("a(x,y,z) = ",a)
 
@@ -46,3 +50,10 @@ def div_a_grad_perp_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
 #   zval = 0.345
 #   print(f"div_a_grad_perp_f({xval},{yval},{zval}) = ",div_a_grad_perp_f_func(xval,yval,zval))
    return div_a_grad_perp_f
+
+def div_par_k_grad_par_f_symbolic(g11, g12, g13, g22, g23, g33, a, f):
+   g_11, g_12, g_13, g_22, g_23, g_33, J = metric_coefficients(g11, g12, g13, g22, g23, g33)
+   dfdy = diff(f,y)
+   k_grad_par_f = a*J*dfdy/g_22
+   div_par_k_grad_par_f = (1/J)*(diff(k_grad_par_f,y))
+   return div_par_k_grad_par_f


### PR DESCRIPTION
The changes included here aim to significantly expand the tests available in `tests/mms`. The following features are added:

 - symbolic operators in the `tests/mms/perpendicular_laplacian.py` module covering all of the differential operators that are present in `neutral_mixed`.
 - extension of `nonorthogonal_test.py` and `orthogonal_test.py` to test the newly added differential operators. This requires some changes to `main.cxx`.
 - an automatic test of the right hand side of the equation solved in `neutral_mixed`. We check that the definition of the right hand side matches the expected convergence order. Note that the expected convergence order is second order (2) when `evolve_momentum = false`, but the observed convergence order is first order or worse when `evolve_momentum = true`.
 - ability to add an external source of momentum to neutrals in `neutral_mixed`.
 - ability to read normalised sources in `neutral_mixed`.

The major addition is the test script `neutral_mixed_ddt_test.py`, which runs the following four tests with prescribed functions `Nd`, `Pd`, `NVd` that are constructed to be functions of `(x,y)` and satisfy the boundary conditions imposed in `neutral_mixed`.

 - `neutral_mixed/evolve_momentum_False_conservation_test_False`. Check the definition of the RHS when `evolve_momentum = false`, by calculating symbolically `ddt(Nd)` and `ddt(Pd)`, and using these symbolic expressions as sources to cancel the numerical `ddt(Nd)` and `ddt(Pd)`, such that the output `ddt(Nd)` and `ddt(Pd)` are of order the discretisation error. The spatial resolution is scanned to check convergence, with the following results.
![fig_0](https://github.com/user-attachments/assets/d17a950f-bbda-4754-a6b0-7a72063edff8)
![fig_1](https://github.com/user-attachments/assets/2bbaa762-b8f5-46fb-a971-d6c082f42fe8)

-  `neutral_mixed/evolve_momentum_False_conservation_test_True`. Check that the RHS when `evolve_momentum = false` conserves `Nd` and `Pd`. The spatial resolution is scanned to check convergence, with the following results. Note that density is exactly conserved but pressure is only conserved within numerical error. A volume integration is done over `ddt(Nd)` and `ddt(Pd)` (without a symbolic source) to obtain these errors.
![fig_0](https://github.com/user-attachments/assets/131bc965-bbe3-4c54-9c38-160fec9ac204)
![fig_1](https://github.com/user-attachments/assets/312e32f3-2f62-4428-bc25-433dc95002a6)

 - `neutral_mixed/evolve_momentum_True_conservation_test_False`. Check the definition of the RHS when `evolve_momentum =true`, by calculating symbolically `ddt(Nd)`, `ddt(NVd)` and `ddt(Pd)`, and using these symbolic expressions as sources to cancel the numerical `ddt(Nd)`, `ddt(NVd)`and `ddt(Pd)`, such that the output `ddt(Nd)`, `ddt(NVd)`and `ddt(Pd)` are of order the discretisation error. The spatial resolution is scanned to check convergence, with the following results.
![fig_1](https://github.com/user-attachments/assets/236867b5-3048-4bb1-91c9-89e849314347)
![fig_2](https://github.com/user-attachments/assets/30de152b-0793-472a-8646-7e1d7480ef4c)
![fig_0](https://github.com/user-attachments/assets/aa45c55d-d74d-47cd-b40d-eaaf1e5d155e)

- `neutral_mixed/evolve_momentum_True_conservation_test_True`. Check that the RHS when `evolve_momentum = true` conserves `Nd` and energy. The spatial resolution is scanned to check convergence, with the following results. Note that conservation is first order accurate for density and less than first order for energy.
![fig_0](https://github.com/user-attachments/assets/dd25f3ac-2485-40be-a673-5cca9e15631c)
![fig_1](https://github.com/user-attachments/assets/491488c5-cfd5-4cc6-a013-261d56fa9bb7)

These tests can be readily extended to test the `ddt()` of other physics modules, or to 3D `(x,y,z)`, allowing for rapid testing of the definition of the equations solved.

Potential issues requiring further work:
 - [ ] Flag documentation issues, with respect to dimensionally incorrect documentation for momentum equation for neutrals, factors of mass in viscous coefficients.
 - [ ] Determine why energy conservation was not observed.
 - [ ] Extend nonorthogonal operators to charged species.
 - [ ] Demonstrate `neutral_mixed` working smoothly with nonorthogonal mesh in realistic physics case.
 - [ ] Improve readme and documentation for tests  -- reviewers please make suggestions.
 - [ ] Anything else raised by reviewers.
