### PR TITLE
Add docker image with xhermes preinstalled

### DIFF
--- a/docker/Jupyter.dockerfile
+++ b/docker/Jupyter.dockerfile
@@ -1,0 +1,4 @@
+# Build this as "hermes3-jupyter"
+FROM jupyter/scipy-notebook
+
+RUN git clone https://github.com/boutproject/xhermes && cd xhermes && pip install -e .

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -51,8 +51,6 @@ services:
     user: ${UID}:${GID}
     volumes:
       - ${PWD}/work:/hermes_project/work
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
     environment:
     - PUID=$UID
     - PGID=$GID
@@ -60,7 +58,6 @@ services:
     - OMPI_ALLOW_RUN_AS_ROOT=1
     - OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     entrypoint: ["image", "run"]
-    # command: ["image", "run", "PATH"]
     command: ""
   fix_permissions:
     # Adjust the permissions of ./work to make sure
@@ -72,3 +69,15 @@ services:
     - PUID=$UID
     - PGID=$GID
     command: ["image", "fix_permissions"]
+  
+  jupyter:
+    image: "hermes3-jupyter"
+    user: root
+    volumes:
+      - ${PWD}/work:/home/jovyan/work
+    ports:
+    - 8888:8888
+    environment:
+    - NB_UID=$UID
+    - NB_GID=$GID
+    attach: false


### PR DESCRIPTION
Add a command to docker compose to let you `docker compose up jupyter` which will launch a Jupyter server on port 8888, which can access the `work` folder. This Jupyter image has `xhermes` preinstalled.

Currently, you'll need to build the jupyter image locally using `docker build -f docker/Jupyter.dockerfile -t hermes3-jupyter .`