### PR TITLE
Smooth floors, improve low density regions

### DIFF
--- a/docs/sphinx/developer.rst
+++ b/docs/sphinx/developer.rst
@@ -426,6 +426,7 @@ objects (Options objects). At the start of each iteration (rhs call) a
 new state is created and contains:
 
 * `time`   BoutReal, the current simulation time
+* `linear` bool. True if the time integrator expects a linear response.
 * `units`
   
   * `seconds`   Multiply by this to get units of seconds

--- a/examples/tokamak-1D/1D-threshold/BOUT.inp
+++ b/examples/tokamak-1D/1D-threshold/BOUT.inp
@@ -83,6 +83,8 @@ lag_jacobian = 500               # How long to wait before Jacobian recalculatio
 atol = 1e-7                      # Absolute tolerance (controls small numbers)
 rtol = 1e-5                      # Relative tolerance (primary convergence control)
 
+matrix_free_operator = true
+
 [sheath_boundary_simple]
 # Sheath boundary at target end
 lower_y = false
@@ -160,7 +162,7 @@ AA = 2
 
 thermal_conduction = true
 diagnose = true
-density_floor = 1e-7
+density_floor = 1e-5
 
 [Nd]
 function = 0.001

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -289,12 +289,13 @@ int Hermes::init(bool restarting) {
   return 0;
 }
 
-int Hermes::rhs(BoutReal time) {
+int Hermes::rhs(BoutReal time, bool linear) {
   // Need to reset the state, since fields may be modified in transform steps
   state = Options();
   
   set(state["time"], time);
   state["units"] = units.copy();
+  set(state["linear"], linear);
 
   // Call all the components
   scheduler->transform(state);

--- a/hermes-3.hxx
+++ b/hermes-3.hxx
@@ -33,7 +33,7 @@ public:
   virtual ~Hermes() {}
 protected:
   int init(bool restarting) override;
-  int rhs(BoutReal t) override;
+  int rhs(BoutReal t, bool linear) override;
   int precon(BoutReal t, BoutReal gamma, BoutReal delta);
 
   /// Add variables to be written to the output file

--- a/include/evolve_pressure.hxx
+++ b/include/evolve_pressure.hxx
@@ -93,6 +93,7 @@ private:
   bool low_T_diffuse_perp; ///< Add cross-field diffusion at low temperature?
   BoutReal pressure_floor; ///< When non-zero pressure is needed
   bool low_p_diffuse_perp; ///< Add artificial cross-field diffusion at low electron pressure?
+  bool damp_p_nt; ///< Damp P - N*T. Active when P < 0 or N < density_floor
 
   Field3D kappa_par; ///< Parallel heat conduction coefficient
 

--- a/include/hermes_utils.hxx
+++ b/include/hermes_utils.hxx
@@ -2,12 +2,42 @@
 #ifndef HERMES_UTILS_H
 #define HERMES_UTILS_H
 
+#include "bout/traits.hxx"
 #include "bout/bout_enum_class.hxx"
 
 inline BoutReal floor(BoutReal value, BoutReal min) {
   if (value < min)
     return min;
   return value;
+}
+
+/// Apply a smoothly varying "soft" floor to the value
+/// The intention is to keep the RHS function differentiable
+///
+/// Note: This function cannot be used with min = 0!
+inline BoutReal softFloor(BoutReal value, BoutReal min) {
+  if (value < 0.0)
+    value = 0.0;
+  return value + min * exp(-value / min);
+}
+
+/// Apply a soft floor value \p f to a field \p var. Any value lower than
+/// the floor is set to the floor.
+///
+/// @param[in] var  Variable to apply floor to
+/// @param[in] f    The floor value. Must be > 0 (NOT zero)
+/// @param[in] rgn  The region to calculate the result over
+template <typename T, typename = bout::utils::EnableIfField<T>>
+inline T softFloor(const T& var, BoutReal f, const std::string& rgn = "RGN_ALL") {
+  checkData(var);
+  T result {emptyFrom(var)};
+  result.allocate();
+
+  BOUT_FOR(d, var.getRegion(rgn)) {
+    result[d] = softFloor(var[d], f);
+  }
+
+  return result;
 }
 
 template<typename T, typename = bout::utils::EnableIfField<T>>

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -47,6 +47,7 @@ private:
   bool sheath_ydown, sheath_yup;
 
   BoutReal density_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
+  BoutReal temperature_floor;
   BoutReal pressure_floor; ///< Minimum Pn used when dividing Pn by Nn to get Tn.
 
   BoutReal flux_limit; ///< Diffusive flux limit

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -49,6 +49,7 @@ private:
   BoutReal density_floor; ///< Minimum Nn used when dividing NVn by Nn to get Vn.
   BoutReal temperature_floor;
   BoutReal pressure_floor; ///< Minimum Pn used when dividing Pn by Nn to get Tn.
+  bool freeze_low_density; ///< Freeze evolution in low density regions?
 
   BoutReal flux_limit; ///< Diffusive flux limit
   BoutReal diffusion_limit;    ///< Maximum diffusion coefficient

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -37,7 +37,7 @@ private:
   Field3D Nn, Pn, NVn; // Density, pressure and parallel momentum
   Field3D Vn; ///< Neutral parallel velocity
   Field3D Tn; ///< Neutral temperature
-  Field3D Nnlim, Pnlim, logPnlim, Vnlim, Tnlim; // Limited in regions of low density
+  Field3D Nnlim, Pnlim, logPnlim; // Limited in regions of low density
 
   BoutReal AA; ///< Atomic mass (proton = 1)
 

--- a/include/neutral_mixed.hxx
+++ b/include/neutral_mixed.hxx
@@ -60,6 +60,7 @@ private:
   Field3D kappa_n, eta_n; ///< Neutral conduction and viscosity
 
   bool precondition {true}; ///< Enable preconditioner?
+  bool precon_laplacexy {false}; ///< Use LaplaceXY?
   bool lax_flux; ///< Use Lax flux for advection terms
   std::unique_ptr<Laplacian> inv; ///< Laplacian inversion used for preconditioning
 

--- a/src/adas_reaction.cxx
+++ b/src/adas_reaction.cxx
@@ -13,20 +13,13 @@
 ///
 
 #include "../include/adas_reaction.hxx"
+#include "../include/hermes_utils.hxx"
 #include "../include/integrate.hxx"
 
 #include "../external/json.hxx"
 
 #include <fstream>
 #include <iterator>
-
-namespace {
-  BoutReal floor(BoutReal value, BoutReal min) {
-    if (value < min)
-      return min;
-    return value;
-  }
-}
 
 OpenADASRateCoefficient::OpenADASRateCoefficient(const std::string& filename, int level) {
   AUTO_TRACE();

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -29,6 +29,9 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
 
   density_floor = options["density_floor"].doc("Minimum density floor").withDefault(1e-7);
 
+  BoutReal temperature_floor = options["temperature_floor"].doc("Low temperature scale for low_T_diffuse_perp")
+    .withDefault<BoutReal>(0.1) / get<BoutReal>(alloptions["units"]["eV"]);
+  
   low_n_diffuse = options["low_n_diffuse"]
                       .doc("Parallel diffusion at low density")
                       .withDefault<bool>(false);
@@ -37,7 +40,7 @@ EvolveDensity::EvolveDensity(std::string name, Options& alloptions, Solver* solv
                            .doc("Perpendicular diffusion at low density")
                            .withDefault<bool>(false);
 
-  pressure_floor = density_floor * (1./get<BoutReal>(alloptions["units"]["eV"]));
+  pressure_floor = density_floor * temperature_floor;
 
   low_p_diffuse_perp = options["low_p_diffuse_perp"]
                            .doc("Perpendicular diffusion at low pressure")

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -181,7 +181,7 @@ void EvolveEnergy::transform(Options& state) {
   }
 
   // Calculate temperature
-  T = P / floor(N, density_floor);
+  T = P / softFloor(N, density_floor);
   P = N * T; // Ensure consistency
 
   set(species["pressure"], P);
@@ -276,7 +276,7 @@ void EvolveEnergy::finally(const Options& state) {
   if (thermal_conduction) {
 
     // Calculate ion collision times
-    const Field3D tau = 1. / floor(get<Field3D>(species["collision_frequency"]), 1e-10);
+    const Field3D tau = 1. / softFloor(get<Field3D>(species["collision_frequency"]), 1e-10);
     const BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
     // Parallel heat conduction
@@ -304,7 +304,7 @@ void EvolveEnergy::finally(const Options& state) {
       Field3D q_fl = kappa_limit_alpha * N * T * sqrt(T / AA);
 
       // This results in a harmonic average of the heat fluxes
-      kappa_par = kappa_par / (1. + abs(q_SH / floor(q_fl, 1e-10)));
+      kappa_par = kappa_par / (1. + abs(q_SH / softFloor(q_fl, 1e-10)));
 
       // Values of kappa on cell boundaries are needed for fluxes
       mesh->communicate(kappa_par);
@@ -512,7 +512,7 @@ void EvolveEnergy::precon(const Options& state, BoutReal gamma) {
   const Field3D N = get<Field3D>(species["density"]);
 
   // Set the coefficient in Div_par( B * Grad_par )
-  Field3D coef = -gamma * kappa_par / floor(N, density_floor);
+  Field3D coef = -gamma * kappa_par / softFloor(N, density_floor);
 
   if (state.isSet("scale_timederivs")) {
     coef *= get<Field3D>(state["scale_timederivs"]);

--- a/src/evolve_momentum.cxx
+++ b/src/evolve_momentum.cxx
@@ -8,14 +8,7 @@
 #include "../include/evolve_momentum.hxx"
 #include "../include/div_ops.hxx"
 #include "../include/hermes_build_config.hxx"
-
-namespace {
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
-  return value;
-}
-}
+#include "../include/hermes_utils.hxx"
 
 using bout::globals::mesh;
 
@@ -29,11 +22,14 @@ EvolveMomentum::EvolveMomentum(std::string name, Options &alloptions, Solver *so
 
   density_floor = options["density_floor"].doc("Minimum density floor").withDefault(1e-7);
 
+  BoutReal temperature_floor = options["temperature_floor"].doc("Low temperature scale for low_T_diffuse_perp")
+    .withDefault<BoutReal>(0.1) / get<BoutReal>(alloptions["units"]["eV"]);
+
   low_n_diffuse_perp = options["low_n_diffuse_perp"]
                            .doc("Perpendicular diffusion at low density")
                            .withDefault<bool>(false);
 
-  pressure_floor = density_floor * (1./get<BoutReal>(alloptions["units"]["eV"]));
+  pressure_floor = density_floor * temperature_floor;
 
   low_p_diffuse_perp = options["low_p_diffuse_perp"]
                            .doc("Perpendicular diffusion at low pressure")
@@ -71,7 +67,7 @@ void EvolveMomentum::transform(Options &state) {
 
   // Not using density boundary condition
   auto N = getNoBoundary<Field3D>(species["density"]);
-  Field3D Nlim = floor(N, density_floor);
+  Field3D Nlim = softFloor(N, density_floor);
   BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
   V = NV / (AA * Nlim);
@@ -98,7 +94,7 @@ void EvolveMomentum::finally(const Options &state) {
   // Get the species density
   Field3D N = get<Field3D>(species["density"]);
   // Apply a floor to the density
-  Field3D Nlim = floor(N, density_floor);
+  Field3D Nlim = softFloor(N, density_floor);
 
   // Typical wave speed used for numerical diffusion
   Field3D fastest_wave;
@@ -145,7 +141,7 @@ void EvolveMomentum::finally(const Options &state) {
           - Div_n_bxGrad_f_B_XPPM(N, phi, bndry_flux, poloidal_flows, true)
           ;
         if (low_n_diffuse_perp) {
-          dndt += Div_Perp_Lap_FV_Index(density_floor / floor(N, 1e-3 * density_floor), N,
+          dndt += Div_Perp_Lap_FV_Index(density_floor / softFloor(N, 1e-3 * density_floor), N,
                                         bndry_flux);
         }
         ddt(NV) += Z * Apar * dndt;
@@ -195,11 +191,11 @@ void EvolveMomentum::finally(const Options &state) {
   }
 
   if (low_n_diffuse_perp) {
-    ddt(NV) += Div_Perp_Lap_FV_Index(density_floor / floor(N, 1e-3 * density_floor), NV, true);
+    ddt(NV) += Div_Perp_Lap_FV_Index(density_floor / softFloor(N, 1e-3 * density_floor), NV, true);
   }
 
   if (low_p_diffuse_perp) {
-    Field3D Plim = floor(get<Field3D>(species["pressure"]), 1e-3 * pressure_floor);
+    Field3D Plim = softFloor(get<Field3D>(species["pressure"]), 1e-3 * pressure_floor);
     ddt(NV) += Div_Perp_Lap_FV_Index(pressure_floor / Plim, NV, true);
   }
 

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -149,7 +149,6 @@ NeutralMixed::NeutralMixed(const std::string& name, Options& alloptions, Solver*
   Nn.setBoundary(std::string("N") + name);
 
   // All floored versions of variables get the same boundary as the original
-  Tnlim.setBoundary(std::string("T") + name);
   Pnlim.setBoundary(std::string("P") + name);
   logPnlim.setBoundary(std::string("P") + name);
   Nnlim.setBoundary(std::string("N") + name);
@@ -179,10 +178,7 @@ void NeutralMixed::transform(Options& state) {
   Tn.applyBoundary();
 
   Vn = NVn / (AA * Nnlim);
-  Vnlim = Vn;
-
   Vn.applyBoundary("neumann");
-  Vnlim.applyBoundary("neumann");
 
   Pnlim = softFloor(Pn, pressure_floor);
   Pnlim.applyBoundary();
@@ -217,7 +213,6 @@ void NeutralMixed::transform(Options& state) {
 
         // No flow into wall
         Vn(r.ind, mesh->ystart - 1, jz) = -Vn(r.ind, mesh->ystart, jz);
-        Vnlim(r.ind, mesh->ystart - 1, jz) = -Vnlim(r.ind, mesh->ystart, jz);
         NVn(r.ind, mesh->ystart - 1, jz) = -NVn(r.ind, mesh->ystart, jz);
       }
     }
@@ -245,7 +240,6 @@ void NeutralMixed::transform(Options& state) {
 
         // No flow into wall
         Vn(r.ind, mesh->yend + 1, jz) = -Vn(r.ind, mesh->yend, jz);
-        Vnlim(r.ind, mesh->yend + 1, jz) = -Vnlim(r.ind, mesh->yend, jz);
         NVn(r.ind, mesh->yend + 1, jz) = -NVn(r.ind, mesh->yend, jz);
       }
     }
@@ -811,7 +805,6 @@ void NeutralMixed::precon(const Options& state, BoutReal gamma) {
   // ( I   E^-1U )
   // ( 0     I   )
 
-  // Note: Tnlim not set anywhere!
   ddt(Nn) -= gamma * FV::Div_a_Grad_perp(DnnNn / Pnlim, ddt(Pn));
 
   if (evolve_momentum) {

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -512,7 +512,7 @@ void NeutralMixed::finally(const Options& state) {
       // Local average density.
       // The purpose is to turn on evolution when nearby cells contain significant density.
       const BoutReal meanNn = (1./6) * (2 * Nn[i] + Nn[i.xp()] + Nn[i.xm()] + Nn[i.yp()] + Nn[i.ym()]);
-      const BoutReal factor = exp(- density_floor / Nn[i]);
+      const BoutReal factor = exp(- density_floor / meanNn);
       ddt(Nn)[i] = factor * ddt(Nn)[i] + (1. - factor) * Nn_s[i];
       ddt(Pn)[i] = factor * ddt(Pn)[i] + (1. - factor) * Pn_s[i];
       ddt(NVn)[i] = factor * ddt(NVn)[i] + (1. - factor) * NVn_s[i];

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -408,12 +408,11 @@ void NeutralMixed::finally(const Options& state) {
                       ef_cond_par_ylow,        
                       false)  // No conduction through target boundary
       ;
+    // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
+    ef_cond_perp_xlow *= 3/2;
+    ef_cond_perp_ylow *= 3/2;
+    ef_cond_par_ylow *= 3/2;
   }
-
-  // The factor here is likely 3/2 as this is pure energy flow, but needs checking.
-  ef_cond_perp_xlow *= 3/2;
-  ef_cond_perp_ylow *= 3/2;
-  ef_cond_par_ylow *= 3/2;
 
   Sp = pressure_source;
   if (localstate.isSet("energy_source")) {

--- a/src/sheath_boundary.cxx
+++ b/src/sheath_boundary.cxx
@@ -1,4 +1,5 @@
 #include "../include/sheath_boundary.hxx"
+#include "../include/hermes_utils.hxx"
 
 #include <bout/output_bout_types.hxx>
 
@@ -12,12 +13,6 @@ BoutReal clip(BoutReal value, BoutReal min, BoutReal max) {
     return min;
   if (value > max)
     return max;
-  return value;
-}
-
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
   return value;
 }
 

--- a/src/sheath_boundary_insulating.cxx
+++ b/src/sheath_boundary_insulating.cxx
@@ -2,6 +2,7 @@
 /// to the wall. Potential (if set) is linearly extrapolated into the boundary.
 
 #include "../include/sheath_boundary_insulating.hxx"
+#include "hermes_utils.hxx"
 
 #include <bout/output_bout_types.hxx>
 
@@ -15,12 +16,6 @@ BoutReal clip(BoutReal value, BoutReal min, BoutReal max) {
     return min;
   if (value > max)
     return max;
-  return value;
-}
-
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
   return value;
 }
 

--- a/src/sheath_boundary_simple.cxx
+++ b/src/sheath_boundary_simple.cxx
@@ -1,4 +1,5 @@
 #include "../include/sheath_boundary_simple.hxx"
+#include "../include/hermes_utils.hxx"
 
 #include "bout/constants.hxx"
 #include "bout/mesh.hxx"
@@ -10,12 +11,6 @@ BoutReal clip(BoutReal value, BoutReal min, BoutReal max) {
     return min;
   if (value > max)
     return max;
-  return value;
-}
-
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
   return value;
 }
 

--- a/src/sound_speed.cxx
+++ b/src/sound_speed.cxx
@@ -1,15 +1,7 @@
 
 #include "../include/sound_speed.hxx"
-
+#include "../include/hermes_utils.hxx"
 #include <bout/mesh.hxx>
-
-namespace {
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
-  return value;
-}
-} // namespace
 
 void SoundSpeed::transform(Options &state) {
   Field3D total_pressure = 0.0;
@@ -39,14 +31,14 @@ void SoundSpeed::transform(Options &state) {
       if (species.isSet("temperature")) {
         auto T = GET_NOBOUNDARY(Field3D, species["temperature"]);
         for (auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
-          BoutReal sound_speed = sqrt(floor(T[i], temperature_floor) / AA);
+          BoutReal sound_speed = sqrt(softFloor(T[i], temperature_floor) / AA);
           fastest_wave[i] = BOUTMAX(fastest_wave[i], sound_speed);
         }
       }
     }
   }
 
-  total_density = floor(total_density, 1e-10);
+  total_density = softFloor(total_density, 1e-10);
   Field3D sound_speed = sqrt(total_pressure / total_density);
   for (auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
     fastest_wave[i] = BOUTMAX(fastest_wave[i], sound_speed[i]);

--- a/src/vorticity.cxx
+++ b/src/vorticity.cxx
@@ -1,6 +1,7 @@
 
 #include "../include/vorticity.hxx"
 #include "../include/div_ops.hxx"
+#include "../include/hermes_utils.hxx"
 
 #include <bout/constants.hxx>
 #include <bout/fv_ops.hxx>
@@ -12,12 +13,6 @@
 using bout::globals::mesh;
 
 namespace {
-BoutReal floor(BoutReal value, BoutReal min) {
-  if (value < min)
-    return min;
-  return value;
-}
-
 Ind3D indexAt(const Field3D& f, int x, int y, int z) {
   int ny = f.getNy();
   int nz = f.getNz();


### PR DESCRIPTION
- Replace "hard" `floor()` function with a differentiable function `softFloor()` when applying non-zero limits. The intention is to avoid non-differentiable switches in the RHS function, making convergence of the solver easier.
- Remove `ddt(P) += N*T - P` term by default in `evolve_pressure`. This term tries to drive `P` toward being consistent with `N * T`, becoming active when `N < density_floor`. This term is the cause of the low neutral temperatures seen in 1D simulations in low density regions. See #303 
- Add a `linear` flag to the state, that is `true` when the time integrator is performing a linear solve. This may be used in components to linearise the RHS and maybe improve performance. See #276 
- Modify `neutral_mixed` so that it consistent with `evolve_density`, `evolve_pressure` and `evolve_momentum`, partly fixing #291

@PoloidalLloyd @mikekryjak Hopefully these fixes improve the slowdowns you saw in 1D simulations #303.