### PR TITLE
Cmake: Ensure Hermes is built with C++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -105,7 +105,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Latest
 TabWidth:        8
 UseTab:          Never
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ add_library(hermes-3-lib ${HERMES_SOURCES})
 
 target_link_libraries(hermes-3-lib PRIVATE bout++::bout++)
 
+target_compile_features(hermes-3-lib PUBLIC cxx_std_17)
+set_target_properties(hermes-3-lib PROPERTIES CXX_EXTENSIONS OFF)
+
 target_include_directories(hermes-3-lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
@@ -242,7 +245,6 @@ if(HERMES_TESTS)
     if(NOT PACKAGE_TESTS)
       # Not running BOUT++ tests
       # Since BOUT++ includes googletest, adding it again causes errors
-      set(CMAKE_CXX_STANDARD 14) # Needed to compile GoogleTest on Darwin
       add_subdirectory(external/googletest)
     endif()
     file(GLOB_RECURSE TEST_SOURCES tests/unit/test_*.cxx)


### PR DESCRIPTION
Minor, but building the tests would force C++14.

Actually, it should be possible to jump straight to C++20, ubuntu 22 has gcc 11, which implements most of C++20