### PR TITLE
evolve_pressure: Initialize flow_ylow if diagnose but no velocity

### DIFF
--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -323,6 +323,8 @@ void EvolvePressure::finally(const Options& state) {
         ddt(P) += Sp_nvh;
       }
     }
+  } else if (diagnose) {
+    flow_ylow = 0;
   }
 
   if (species.isSet("low_n_coeff")) {


### PR DESCRIPTION
If velocity is not set then `flow_ylow` was not initialized. This is a diagnostic output that is only needed if `diagnose=true`.