### PR TITLE
fixed_velocity: Read velocity from mesh

### DIFF
--- a/include/fixed_velocity.hxx
+++ b/include/fixed_velocity.hxx
@@ -3,6 +3,7 @@
 #define FIXED_VELOCITY_H
 
 #include "component.hxx"
+#include <bout/globals.hxx>
 
 /// Set parallel velocity to a fixed value
 ///
@@ -19,7 +20,14 @@ struct FixedVelocity : public Component {
     const BoutReal Cs0 = units["meters"].as<BoutReal>() / units["seconds"].as<BoutReal>();
 
     // Get the velocity and normalise
-    V = options["velocity"].as<Field3D>() / Cs0;
+    // First read from the mesh file e.g. "Ve0"
+    if ((bout::globals::mesh->get(V, std::string("V") + name + "0") != 0) and
+        !options.isSet("velocity")) {
+      throw BoutException("fixed_velocity: Missing mesh V{}0 or option {}:velocity\n", name, name);
+    }
+    // Option overrides mesh value
+    // so use mesh value (if any) as default value.
+    V = options["velocity"].withDefault(V) / Cs0;
   }
 
   /// This sets in the state


### PR DESCRIPTION
If species name is "d+" then this first tries to read "Vd+0" as a Field3D from the mesh file. Should be stored in the file in SI units (m/s).

The mesh file value is used as the default value when reading from options, as before.

If neither mesh nor option value are present then an exception will be thrown.