### PR TITLE
Fix conduction collisionality when mode = braginskii

### DIFF
--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -438,7 +438,7 @@ void EvolvePressure::finally(const Options& state) {
 
 
     // Calculate ion collision times
-    const Field3D tau = 1. / softFloor(get<Field3D>(species["collision_frequency"]), 1e-10);
+    const Field3D tau = 1. / softFloor(nu, 1e-10);
     const BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
     // Parallel heat conduction


### PR DESCRIPTION
The Hermes-3 closure was originally Braginskii but counting the frequency the collisions of a particular species with any other species as long as they are enabled. A PR was merged (https://github.com/boutproject/hermes-3/pull/195) to allow the collision selection to comply with proper Braginskii, i.e. `ee` collisions only for conduction and so on. This makes multiple main ion simulations not accurate, but allows a better comparison to other codes which usually have a pure Braginskii setting.

Prior to this PR, conduction got the collision frequency from `state["collision_frequency"]`: 
https://github.com/boutproject/hermes-3/blob/07dca63c1f8eef7d1a874ef5f3a5e2252fc198f3/src/evolve_pressure.cxx#L441

I created a new map called `state["collision_frequencies"]` where individual collision frequencies were saved, and a very clunky string parser to choose the right collisions on a per component basis: https://github.com/boutproject/hermes-3/blob/07dca63c1f8eef7d1a874ef5f3a5e2252fc198f3/src/evolve_pressure.cxx#L353-L416

I kept the original `state["collision_frequency"]` object because I wanted to make sure I don't break anything - I was going to remove it later, but I ran out of time and we decided to merge it in considering that we had a major closure refactor coming up anyway.

What I just found is that I created a bug when merging the PR - all the machinery for choosing the collisionality was correct, but then the one used was the original one from `state["collision_frequency"]` due to a simple omission:
https://github.com/boutproject/hermes-3/blob/07dca63c1f8eef7d1a874ef5f3a5e2252fc198f3/src/evolve_pressure.cxx#L441. The pure Braginskii mode was verified against ReMKiT1D on my fork, but not after the merge... and there is no test to cover the `braginskii` mode.

In terms of impact, the bug meant that if the user chose the `braginskii` mode, conduction would still pick up all the enabled collisions, not just the ones requested (i.e. `ee`). In practice this means your temperature gradient will be too steep as it's picking up `ei` collisions, and there would be no issues in `multispecies` mode since that already counts all enabled collisions.

This PR fixes it. Thankfully with the upcoming closure refactor we'll have a lot more tests and we'll get rid of the clunky string parser.

