### PR TITLE
Fix reaction string extraction

### DIFF
--- a/include/adas_reaction.hxx
+++ b/include/adas_reaction.hxx
@@ -3,6 +3,7 @@
 #define ADAS_REACTION_H
 
 #include "component.hxx"
+#include "reaction.hxx"
 #include <vector>
 
 /// Represent a 2D rate coefficient table (T,n)
@@ -34,7 +35,7 @@ struct OpenADASRateCoefficient {
 ///
 /// Uses the JSON files produced by:
 ///   https://github.com/TBody/OpenADAS_to_JSON
-struct OpenADAS : public Component {
+struct OpenADAS : public ReactionBase {
   ///
   /// Inputs
   /// ------
@@ -77,7 +78,7 @@ private:
   BoutReal Tnorm, Nnorm, FreqNorm; ///< Normalisations
 };
 
-struct OpenADASChargeExchange : public Component {
+struct OpenADASChargeExchange : public ReactionBase {
   OpenADASChargeExchange(const Options& units, const std::string& rate_file, int level)
       : rate_coef(std::string("json_database/") + rate_file, level) {
     // Get the units

--- a/include/hydrogen_charge_exchange.hxx
+++ b/include/hydrogen_charge_exchange.hxx
@@ -5,7 +5,7 @@
 #include <bout/constants.hxx>
 
 #include "component.hxx"
-
+#include "reaction.hxx"
 /// Hydrogen charge exchange total rate coefficient
 ///
 ///   p + H(1s) -> H(1s) + p
@@ -22,7 +22,7 @@
 ///            should probably be disabled in the `collisions` component,
 ///            to avoid double-counting.
 ///
-struct HydrogenChargeExchange : public Component {
+struct HydrogenChargeExchange : public ReactionBase {
   ///
   /// @param alloptions Settings, which should include:
   ///        - units

--- a/include/reaction.hxx
+++ b/include/reaction.hxx
@@ -10,16 +10,27 @@
 typedef Options& (*OPTYPE)(Options&, Field3D);
 
 /**
- * @brief Struct intended to act as a base for all reactions.
- *
+ * @brief Temporary struct to use as a base class for all reactions components. Ensures
+ * reaction strings are paired up correctly with component classes. Can be removed when
+ * all reaction classes have been refactored to inherit from Reaction.
  */
-struct Reaction : public Component {
-  Reaction(std::string name, Options& alloptions);
-
+struct ReactionBase : public Component {
+  ReactionBase() : inst_num(get_instance_num() + 1) {}
   static int get_instance_num() {
     static int instance_num{0};
     return instance_num++;
   }
+
+protected:
+  int inst_num;
+};
+
+/**
+ * @brief Struct intended to act as a base for all reactions.
+ *
+ */
+struct Reaction : public ReactionBase {
+  Reaction(std::string name, Options& alloptions);
 
   void transform(Options& state) override final;
 

--- a/include/solkit_hydrogen_charge_exchange.hxx
+++ b/include/solkit_hydrogen_charge_exchange.hxx
@@ -3,10 +3,10 @@
 #define SOLKIT_HYDROGEN_CHARGE_EXCHANGE_H
 
 #include "component.hxx"
-
+#include "reaction.hxx"
 /// SOL-KiT Hydrogen charge exchange total rate coefficient
 ///
-struct SOLKITHydrogenChargeExchange : public Component {
+struct SOLKITHydrogenChargeExchange : public ReactionBase {
   ///
   /// @param alloptions Settings, which should include:
   ///        - units

--- a/src/reaction.cxx
+++ b/src/reaction.cxx
@@ -31,8 +31,7 @@ Reaction::Reaction(std::string name, Options& options) : name(name) {
   reaction_grp_str = std::regex_replace(reaction_grp_str, match_parentheses, "");
   std::string reaction_str;
   std::stringstream ss(reaction_grp_str);
-  int inst_num = get_instance_num() + 1;
-  for (auto ii = 0; ii < inst_num; ii++) {
+  for (auto ii = 0; ii < this->inst_num; ii++) {
     std::getline(ss, reaction_str, ',');
   }
 


### PR DESCRIPTION
Adds a temporary struct from which all reaction component classes inherit.
Interim solution until the reactions refactoring is finished!

Fixes #395 