### PR TITLE
Refactor closure so can use other forms

### DIFF
--- a/src/collisions.cxx
+++ b/src/collisions.cxx
@@ -438,7 +438,7 @@ void Collisions::transform(Options& state) {
         const BoutReal AA2 = get<BoutReal>(species2["AA"]);
         const Field3D density2 = GET_NOBOUNDARY(Field3D, species2["density"]) * Nnorm;
 
-        if (species2.isSet("charge")) {
+        if (species2.isSet("charge") and (get<BoutReal>(species2["charge"]) != 0.0)) {
           // species1 neutral, species2 charged
 
           if (!ion_neutral)

--- a/src/evolve_energy.cxx
+++ b/src/evolve_energy.cxx
@@ -356,7 +356,7 @@ void EvolveEnergy::finally(const Options& state) {
     }
 
     // Calculate ion collision times
-    const Field3D tau = 1. / softFloor(get<Field3D>(species["collision_frequency"]), 1e-10);
+    const Field3D tau = 1. / softFloor(nu, 1e-10);
     const BoutReal AA = get<BoutReal>(species["AA"]); // Atomic mass
 
     // Parallel heat conduction

--- a/src/thermal_force.cxx
+++ b/src/thermal_force.cxx
@@ -22,7 +22,7 @@ void ThermalForce::transform(Options& state) {
       }
       Options& species = allspecies[kv.first];
 
-      if (!species.isSet("charge")) {
+      if (!species.isSet("charge") or species["charge"] == 0) {
         continue; // Only considering charged particle interactions
       }
 
@@ -54,7 +54,7 @@ void ThermalForce::transform(Options& state) {
     for (auto kv1 = std::begin(children); kv1 != std::end(children); ++kv1) {
       Options& species1 = allspecies[kv1->first];
 
-      if (kv1->first == "e" or !species1.isSet("charge")) {
+      if (kv1->first == "e" or !species1.isSet("charge") or species1["charge"] == 0) {
         continue; // Only considering charged particle interactions
       }
 
@@ -64,7 +64,7 @@ void ThermalForce::transform(Options& state) {
            kv2 != std::end(children); ++kv2) {
         Options& species2 = allspecies[kv2->first];
 
-        if (kv2->first == "e" or !species2.isSet("charge")) {
+        if (kv2->first == "e" or !species2.isSet("charge") or species2["charge"] == 0) {
           continue; // Only considering charged particle interactions
         }
 

--- a/tests/unit/test_braginskii_collisions.cxx
+++ b/tests/unit/test_braginskii_collisions.cxx
@@ -17,9 +17,9 @@ extern Mesh *mesh;
 using namespace bout::globals;
 
 // Reuse the "standard" fixture for FakeMesh
-using CollisionsTest = FakeMeshFixture;
+using BraginskiiCollisionsTest = FakeMeshFixture;
 
-TEST_F(CollisionsTest, CreateComponent) {
+TEST_F(BraginskiiCollisionsTest, CreateComponent) {
   Options options;
   
   options["units"]["eV"] = 1.0;
@@ -29,7 +29,7 @@ TEST_F(CollisionsTest, CreateComponent) {
   Collisions component("test", options, nullptr);
 }
 
-TEST_F(CollisionsTest, OnlyElectrons) {
+TEST_F(BraginskiiCollisionsTest, OnlyElectrons) {
   Options options;
 
   options["units"]["eV"] = 1.0;
@@ -48,7 +48,7 @@ TEST_F(CollisionsTest, OnlyElectrons) {
   ASSERT_TRUE(state["species"]["e"].isSet("collision_frequency"));
 }
 
-TEST_F(CollisionsTest, OneOrTwoSpeciesCharged) {
+TEST_F(BraginskiiCollisionsTest, OneOrTwoSpeciesCharged) {
   Options options;
 
   options["units"]["eV"] = 1.0;
@@ -91,7 +91,7 @@ TEST_F(CollisionsTest, OneOrTwoSpeciesCharged) {
   }
 }
 
-TEST_F(CollisionsTest, TnormDependence) {
+TEST_F(BraginskiiCollisionsTest, TnormDependence) {
   // Calculate rates with normalisation factors 1
   Options options {{"units", {{"eV", 1.0},
                               {"meters", 1.0},

--- a/tests/unit/test_braginskii_conduction.cxx
+++ b/tests/unit/test_braginskii_conduction.cxx
@@ -1,0 +1,195 @@
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/evolve_pressure.hxx"
+#include "../../include/evolve_energy.hxx"
+#include <bout/solver.hxx>
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+template <typename T>
+class BraginskiiConductionTest
+  : public FakeMeshFixture {
+public:
+  BraginskiiConductionTest()
+      : FakeMeshFixture(),
+        options({{"units",
+                  {{"eV", 1.0},
+                   {"meters", 1.0},
+                   {"seconds", 1.0},
+                   {"inv_meters_cubed", 1e19}}},
+                 {"test+", {{"thermal_conduction", true}, {"diagnose", true}}},
+                 {"solver", {{"type", "euler"}}}}),
+        output_base({{"Nnorm", 1e19}, {"Tnorm", 1.}, {"Omega_ci", 1.}, {"rho_s0", 1.}}),
+        state_base({{"fastest_wave", 0.}, {"species", {{"test+", {{"velocity", 0.}, {"density", 1.}, {"pressure", 1.}, { "AA", 2. }}}}}}) {
+    Options::root()["Ptest+"]["function"] = "1.0";
+    temp1 = quadraticGradient(1., 0., 0., 1., 1., 0., 0.);
+    temp2 = quadraticGradient(0., 0., 0., 1., 2., 0., 0.);
+    temp_perp_variation = quadraticGradient(0., 1., 2., 0., 0., 0., 0.);
+  }
+  Options options, output_base, state_base;
+  Field3D temp1, temp2, temp_perp_variation;
+
+  static Field3D quadraticGradient(BoutReal a, BoutReal b1_x, BoutReal b2_x, BoutReal b1_y,
+                                 BoutReal b2_y, BoutReal b1_z, BoutReal b2_z) {
+    Field3D result(a);
+    BOUT_FOR_SERIAL(i, result.getRegion("RGN_ALL")) {
+      const int x = i.x(), y = i.y(), z = i.z();
+      result[i] +=
+          b1_x * x + b2_x * SQ(x) + b1_y * y + b2_y * SQ(y) + b1_z * z + b2_z * SQ(z);
+    }
+    return result;
+  }
+
+  T makeComponent(BoutReal kappa, std::string mode = "braginskii") {
+    Options opts = options.copy();
+    opts["test+"]["kappa_coefficient"] = kappa;
+    opts["test+"]["conduction_collisions_mode"] = mode;
+    // FIXME: The first time this is called it will result in a call
+    // to MPI_Init, which is slow. Is there some way to fake/avoid
+    // that?
+    auto solver = Solver::create(&(options["solver"]));
+    return T("test+", opts, solver.get());
+  }
+
+  Field3D getDeriv(const Options& state);
+};
+
+template <>
+Field3D BraginskiiConductionTest<EvolveEnergy>::getDeriv(const Options& state) {
+  return state["ddt(Etest+)"];
+}
+
+template <>
+Field3D BraginskiiConductionTest<EvolvePressure>::getDeriv(const Options& state) {
+  return state["ddt(Ptest+)"];
+}
+
+using EnergyTypes = ::testing::Types<EvolvePressure, EvolveEnergy>;
+TYPED_TEST_SUITE(BraginskiiConductionTest, EnergyTypes);
+
+TYPED_TEST(BraginskiiConductionTest, ConductionGradientScaling) {
+  TypeParam component = this->makeComponent(1.);
+  Options state0, state1 = this->state_base.copy(), state2;
+  state1["species"]["test+"]["charge"] = 1;
+  state1["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 1.;
+  state1["species"]["test+"]["collision_frequency"] = 1.;
+
+  state0 = state1.copy();
+  state2 = state1.copy();
+
+  state0["species"]["test+"]["temperature"] = this->temp_perp_variation;
+  state1["species"]["test+"]["temperature"] = this->temp1;
+  state2["species"]["test+"]["temperature"] = this->temp2;
+
+  Options output0 = this->output_base.copy(), output1 = this->output_base.copy(), output2 = this->output_base.copy();
+
+  component.finally(state0);
+  component.outputVars(output0);
+  component.finally(state1);
+  component.outputVars(output1);
+  component.finally(state2);
+  component.outputVars(output2);
+  
+  Field3D conduction0 = this->getDeriv(output0), conduction1 = this->getDeriv(output1), conduction2 = this->getDeriv(output2);
+BOUT_FOR_SERIAL(i, conduction1.getRegion("RGN_NOBNDRY")) {
+    // Conduction is proportional to the parallel second derivative of temperature
+    EXPECT_NE(conduction1[i], 0.);
+    EXPECT_FLOAT_EQ(conduction0[i], 0.);
+    EXPECT_FLOAT_EQ(conduction2[i], 2*conduction1[i]);
+  }
+}
+
+TYPED_TEST(BraginskiiConductionTest, ConductionKappaScaling) {
+  TypeParam component1 = this->makeComponent(1.), component2 = this->makeComponent(2.);
+  Options state = this->state_base.copy();
+  state["species"]["test+"]["charge"] = 1;
+  state["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 1.;
+  state["species"]["test+"]["collision_frequency"] = 1.;
+  state["species"]["test+"]["temperature"] = this->temp1;
+
+  Options  output1 = this->output_base.copy(), output2 = this->output_base.copy();
+
+  component1.finally(state);
+  component1.outputVars(output1);
+  component2.finally(state);
+  component2.outputVars(output2);
+  
+  Field3D conduction1 = this->getDeriv(output1), conduction2 = this->getDeriv(output2);
+BOUT_FOR_SERIAL(i, conduction1.getRegion("RGN_NOBNDRY")) {
+    // Conduction is proportional to the parallel diffusivity
+    EXPECT_NE(conduction1[i], 0.);
+    EXPECT_FLOAT_EQ(conduction2[i], 2*conduction1[i]);
+  }
+}
+
+
+TYPED_TEST(BraginskiiConductionTest, ConductionCollisionScaling) {
+  TypeParam component = this->makeComponent(1.);
+  Options state0, state1 = this->state_base.copy(), state2;
+  state1["species"]["test+"]["charge"] = 1;
+  state1["species"]["test+"]["temperature"] = this->temp1;
+
+  state0 = state1.copy();
+  state2 = state1.copy();
+
+  state0["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 0.5;
+  state0["species"]["test+"]["collision_frequency"] = 0.5;
+  state1["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 1.;
+  state1["species"]["test+"]["collision_frequency"] = 1.;
+  state2["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 2.;
+  state2["species"]["test+"]["collision_frequency"] = 2.;
+
+  Options output0 = this->output_base.copy(), output1 = this->output_base.copy(), output2 = this->output_base.copy();
+
+  component.finally(state0);
+  component.outputVars(output0);
+  component.finally(state1);
+  component.outputVars(output1);
+  component.finally(state2);
+  component.outputVars(output2);
+  
+  Field3D conduction0 = this->getDeriv(output0), conduction1 = this->getDeriv(output1), conduction2 = this->getDeriv(output2);
+BOUT_FOR_SERIAL(i, conduction1.getRegion("RGN_NOBNDRY")) {
+    // Conduction is inversely proportional to the collision frequency
+    EXPECT_NE(conduction1[i], 0.);
+    EXPECT_FLOAT_EQ(conduction0[i], 2*conduction1[i]);
+    EXPECT_FLOAT_EQ(2*conduction2[i], conduction1[i]);
+  }
+}
+
+
+TYPED_TEST(BraginskiiConductionTest, ConductionCollisionsMode) {
+  TypeParam component_braginskii = this->makeComponent(1., "braginskii"), component_multispecies = this->makeComponent(1., "multispecies");
+  Options state = this->state_base.copy();
+  state["species"]["test+"]["charge"] = 1;
+  state["species"]["test+"]["temperature"] = this->temp1;
+  state["species"]["test+"]["collision_frequencies"]["test+_test+_coll"] = 0.5;
+  state["species"]["test+"]["collision_frequencies"]["test+_e_coll"] = 0.5;
+  state["species"]["test+"]["collision_frequency"] = 1.0;
+
+  Options output_brag = this->output_base.copy(), output_multi = this->output_base.copy();
+
+  component_braginskii.finally(state);
+  component_braginskii.outputVars(output_brag);
+  component_multispecies.finally(state);
+  component_multispecies.outputVars(output_multi);
+  
+  Field3D conduction_brag = this->getDeriv(output_brag), conduction_multi = this->getDeriv(output_multi);
+  BOUT_FOR_SERIAL(i, conduction_brag.getRegion("RGN_NOBNDRY")) {
+    // Conduction is inversely proportional to the collision frequency
+    EXPECT_NE(conduction_brag[i], 0.);
+    EXPECT_FLOAT_EQ(conduction_brag[i], 2*conduction_multi[i]);
+  }
+}

--- a/tests/unit/test_braginskii_friction.cxx
+++ b/tests/unit/test_braginskii_friction.cxx
@@ -1,0 +1,213 @@
+
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/collisions.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+using BraginskiiFrictionTest = FakeMeshFixture;
+
+
+TEST_F(BraginskiiFrictionTest, OnlyElectrons) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  Options state;
+  state["species"]["e"]["density"] = 1e19;
+  state["species"]["e"]["temperature"] = 10.;
+  state["species"]["e"]["velocity"] = 1.;
+
+  component.transform(state);
+
+  // A species can't exert friction on itself, so momentum and energy transfer won't be set or will be 0.
+  if (state["species"]["e"]["momentum_source"].isSet()) {
+    ASSERT_FLOAT_EQ(get<Field3D>(state["species"]["e"]["momentum_source"])(0, 0, 0), 0.);
+    ASSERT_FLOAT_EQ(get<Field3D>(state["species"]["e"]["energy_source"])(0, 0, 0), 0.);
+  } else {
+    ASSERT_FALSE(state["species"]["e"]["energy_source"].isSet());
+  }
+}
+
+TEST_F(BraginskiiFrictionTest, TwoComovingSpeciesCharged) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state;
+  state["species"]["s1"]["density"] = 5e18; // Half density
+  state["species"]["s1"]["temperature"] = 10;
+  state["species"]["s1"]["charge"] = 1;
+  state["species"]["s1"]["AA"] = 2;
+  state["species"]["s1"]["velocity"] = 1;
+
+  state["species"]["s2"] = state["species"]["s1"].copy();
+
+  // Run calculations
+  component.transform(state);
+  ASSERT_TRUE(state["species"]["s1"].isSet("momentum_source"));
+  ASSERT_TRUE(state["species"]["s2"].isSet("momentum_source"));
+  ASSERT_TRUE(state["species"]["s1"].isSet("energy_source"));
+  ASSERT_TRUE(state["species"]["s2"].isSet("energy_source"));
+
+  Field3D ms1 = get<Field3D>(state["species"]["s1"]["momentum_source"]);
+  Field3D ms2 = get<Field3D>(state["species"]["s2"]["momentum_source"]);
+  Field3D es1 = get<Field3D>(state["species"]["s1"]["energy_source"]);
+  Field3D es2 = get<Field3D>(state["species"]["s2"]["energy_source"]);
+  
+  BOUT_FOR_SERIAL(i, ms1.getRegion("RGN_ALL")) {
+    // If the species have the same velocities, there should be no friction
+    ASSERT_DOUBLE_EQ(ms1[i], 0.);
+    ASSERT_DOUBLE_EQ(ms2[i], 0.);
+    ASSERT_DOUBLE_EQ(es1[i], 0.);
+    ASSERT_DOUBLE_EQ(es2[i], 0.);
+  }
+}
+
+
+TEST_F(BraginskiiFrictionTest, TwoSpeciesCharged) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state;
+  state["species"]["s1"]["density"] = 5e18; // Half density
+  state["species"]["s1"]["temperature"] = 10;
+  state["species"]["s1"]["charge"] = 1;
+  state["species"]["s1"]["AA"] = 2;
+
+  state["species"]["s2"] = state["species"]["s1"].copy();
+
+  state["species"]["s1"]["velocity"] = 1;
+  state["species"]["s2"]["velocity"] = 2;
+
+  // Run calculations
+  component.transform(state);
+
+  Field3D ms1 = get<Field3D>(state["species"]["s1"]["momentum_source"]);
+  Field3D ms2 = get<Field3D>(state["species"]["s2"]["momentum_source"]);
+  Field3D es1 = get<Field3D>(state["species"]["s1"]["energy_source"]);
+  Field3D es2 = get<Field3D>(state["species"]["s2"]["energy_source"]);
+
+  BOUT_FOR_SERIAL(i, ms1.getRegion("RGN_ALL")) {
+    // The species should have opposite momentum sources
+    ASSERT_NE(ms1[i], 0.);
+    ASSERT_DOUBLE_EQ(ms1[i], -ms2[i]);
+    // The species should have equal frictional heating
+    ASSERT_NE(es1[i], 0.);
+    ASSERT_DOUBLE_EQ(es1[i], es2[i]);
+  }
+}
+
+
+TEST_F(BraginskiiFrictionTest, DoubleRelativeVelocities) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state1, state2;
+  state1["species"]["s1"]["density"] = 5e18; // Half density
+  state1["species"]["s1"]["temperature"] = 10;
+  state1["species"]["s1"]["charge"] = 1;
+  state1["species"]["s1"]["AA"] = 2;
+
+  state1["species"]["s2"] = state1["species"]["s1"].copy();
+  state2 = state1.copy();
+
+  state1["species"]["s1"]["velocity"] = 1;
+  state1["species"]["s2"]["velocity"] = 2;
+  state2["species"]["s1"]["velocity"] = 1;
+  state2["species"]["s2"]["velocity"] = 3;
+
+  // Run calculations
+  component.transform(state1);
+  component.transform(state2);
+
+  Field3D ms11 = get<Field3D>(state1["species"]["s1"]["momentum_source"]);
+  Field3D ms21 = get<Field3D>(state2["species"]["s1"]["momentum_source"]);
+  Field3D es11 = get<Field3D>(state1["species"]["s1"]["energy_source"]);
+  Field3D es21 = get<Field3D>(state2["species"]["s1"]["energy_source"]);
+  
+  BOUT_FOR_SERIAL(i, ms11.getRegion("RGN_ALL")) {
+    // The relative velocity in the second state is double that in the
+    // first, so the friction should be double too.
+    ASSERT_NE(ms11[i], 0.);
+    ASSERT_DOUBLE_EQ(2. * ms11[i], ms21[i]);
+    // The the frictional heating depends on the relative velocity
+    // squared, so that of the second species should be quadruple that
+    // of the first.
+    ASSERT_NE(es11[i], 0.);
+    ASSERT_DOUBLE_EQ(4. * es11[i], es21[i]);
+  }
+}
+
+TEST_F(BraginskiiFrictionTest, TwoSpeciesNoHeating) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  options["test"]["frictional_heating"] = false;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state;
+  state["species"]["s1"]["density"] = 5e18; // Half density
+  state["species"]["s1"]["temperature"] = 10;
+  state["species"]["s1"]["charge"] = 1;
+  state["species"]["s1"]["AA"] = 2;
+
+  state["species"]["s2"] = state["species"]["s1"].copy();
+
+  state["species"]["s1"]["velocity"] = 1;
+  state["species"]["s2"]["velocity"] = 2;
+
+  // Run calculations
+  component.transform(state);
+
+  Field3D es1 = get<Field3D>(state["species"]["s1"]["energy_source"]);
+  Field3D es2 = get<Field3D>(state["species"]["s2"]["energy_source"]);
+  
+  BOUT_FOR_SERIAL(i, es1.getRegion("RGN_ALL")) {
+    // Frictional heating is turned off, so this should be zero
+    ASSERT_DOUBLE_EQ(es1[i], 0.);
+    ASSERT_DOUBLE_EQ(es2[i], 0.);
+  }
+}

--- a/tests/unit/test_braginskii_heat_exchange.cxx
+++ b/tests/unit/test_braginskii_heat_exchange.cxx
@@ -153,8 +153,6 @@ TEST_F(BraginskiiHeatExchangeTest, DoubleTemperatureDiff) {
 
   const BoutReal factor = 2. * 2. / sqrt(3.);
   BOUT_FOR_SERIAL(i, es11.getRegion("RGN_ALL")) {
-    // The temperature difference in the second state is double that in the
-    // first, so the heat exchange should be double too.
     ASSERT_DOUBLE_EQ(factor * es11[i], es21[i]);
   }
 }

--- a/tests/unit/test_braginskii_heat_exchange.cxx
+++ b/tests/unit/test_braginskii_heat_exchange.cxx
@@ -1,0 +1,160 @@
+
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/collisions.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+using BraginskiiHeatExchangeTest = FakeMeshFixture;
+
+
+TEST_F(BraginskiiHeatExchangeTest, OnlyElectrons) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  Options state;
+  state["species"]["e"]["density"] = 1e19;
+  state["species"]["e"]["temperature"] = 10.;
+  state["species"]["e"]["velocity"] = 1.;
+
+  component.transform(state);
+
+  // A species can't exchange heat with itself
+  if (state["species"]["e"]["momentum_source"].isSet()) {
+    ASSERT_FLOAT_EQ(get<Field3D>(state["species"]["e"]["energy_source"])(0,0,0), 0.);
+  }
+}
+
+TEST_F(BraginskiiHeatExchangeTest, TwoEqualTempSpeciesCharged) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state;
+  state["species"]["s1"]["density"] = 5e18; // Half density
+  state["species"]["s1"]["temperature"] = 10;
+  state["species"]["s1"]["charge"] = 1;
+  state["species"]["s1"]["AA"] = 2;
+  state["species"]["s1"]["velocity"] = 1;
+
+  state["species"]["s2"] = state["species"]["s1"].copy();
+
+  // Run calculations
+  component.transform(state);
+  ASSERT_TRUE(state["species"]["s1"].isSet("momentum_source"));
+  ASSERT_TRUE(state["species"]["s2"].isSet("momentum_source"));
+  ASSERT_TRUE(state["species"]["s1"].isSet("energy_source"));
+  ASSERT_TRUE(state["species"]["s2"].isSet("energy_source"));
+
+  Field3D ms1 = get<Field3D>(state["species"]["s1"]["momentum_source"]);
+  Field3D ms2 = get<Field3D>(state["species"]["s2"]["momentum_source"]);
+  Field3D es1 = get<Field3D>(state["species"]["s1"]["energy_source"]);
+  Field3D es2 = get<Field3D>(state["species"]["s2"]["energy_source"]);
+  
+  BOUT_FOR_SERIAL(i, ms1.getRegion("RGN_ALL")) {
+    // If the species have the same velocities, there should be no friction
+    ASSERT_DOUBLE_EQ(ms1[i], 0.);
+    ASSERT_DOUBLE_EQ(ms2[i], 0.);
+    ASSERT_DOUBLE_EQ(es1[i], 0.);
+    ASSERT_DOUBLE_EQ(es2[i], 0.);
+  }
+}
+
+
+TEST_F(BraginskiiHeatExchangeTest, TwoSpeciesCharged) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state;
+  state["species"]["s1"]["density"] = 5e18; // Half density
+  state["species"]["s1"]["charge"] = 1;
+  state["species"]["s1"]["AA"] = 2;
+  state["species"]["s1"]["velocity"] = 1;
+
+  state["species"]["s2"] = state["species"]["s1"].copy();
+
+  state["species"]["s1"]["temperature"] = 10;
+  state["species"]["s2"]["temperature"] = 20;
+
+  // Run calculations
+  component.transform(state);
+
+  Field3D es1 = get<Field3D>(state["species"]["s1"]["energy_source"]);
+  Field3D es2 = get<Field3D>(state["species"]["s2"]["energy_source"]);
+
+  BOUT_FOR_SERIAL(i, es1.getRegion("RGN_ALL")) {
+    // The species should have opposite heat exchange
+    ASSERT_DOUBLE_EQ(es1[i], -es2[i]);
+  }
+}
+
+TEST_F(BraginskiiHeatExchangeTest, DoubleTemperatureDiff) {
+  Options options;
+
+  options["units"]["eV"] = 1.0;
+  options["units"]["meters"] = 1.0;
+  options["units"]["seconds"] = 1.0;
+  options["units"]["inv_meters_cubed"] = 1.0;
+  
+  Collisions component("test", options, nullptr);
+
+  // State with two species, both the same but half the density
+  Options state1, state2;
+  state1["species"]["s1"]["density"] = 5e18; // Half density
+  state1["species"]["s1"]["charge"] = 0;
+  state1["species"]["s1"]["AA"] = 2;
+  state1["species"]["s1"]["velocity"] = 1;
+
+  state1["species"]["s2"] = state1["species"]["s1"].copy();
+  state2 = state1.copy();
+
+  state1["species"]["s1"]["temperature"] = 10;
+  state1["species"]["s2"]["temperature"] = 20;
+  state2["species"]["s1"]["temperature"] = 10;
+  state2["species"]["s2"]["temperature"] = 30;
+
+  // Run calculations
+  component.transform(state1);
+  component.transform(state2);
+
+  Field3D es11 = get<Field3D>(state1["species"]["s1"]["energy_source"]);
+  Field3D es21 = get<Field3D>(state2["species"]["s1"]["energy_source"]);
+
+  const BoutReal factor = 2. * 2. / sqrt(3.);
+  BOUT_FOR_SERIAL(i, es11.getRegion("RGN_ALL")) {
+    // The temperature difference in the second state is double that in the
+    // first, so the heat exchange should be double too.
+    ASSERT_DOUBLE_EQ(factor * es11[i], es21[i]);
+  }
+}

--- a/tests/unit/test_braginskii_thermal_force.cxx
+++ b/tests/unit/test_braginskii_thermal_force.cxx
@@ -1,0 +1,291 @@
+
+#include "gtest/gtest.h"
+
+#include "test_extras.hxx" // FakeMesh
+#include "fake_mesh_fixture.hxx"
+
+#include "../../include/thermal_force.hxx"
+
+/// Global mesh
+namespace bout{
+namespace globals{
+extern Mesh *mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+// Reuse the "standard" fixture for FakeMesh
+class BraginskiiThermalForceTest
+  : public FakeMeshFixture {
+public:
+  BraginskiiThermalForceTest()
+      : FakeMeshFixture(), options({{"units",
+                                     {{"eV", 1.0},
+                                      {"meters", 1.0},
+                                      {"seconds", 1.0},
+                                      {"inv_meters_cubed", 1e19}}}}),
+        component("test", options, nullptr) {
+    grad1 = linearGradient(1., 0., 1., 0.);
+    grad2 = linearGradient(0., 0., 2., 0.);
+    grad_perp = linearGradient(0., 1., 0., 0.);
+  }
+  Options options;
+  ThermalForce component;
+  Field3D grad1, grad2, grad_perp;
+
+  static Field3D linearGradient(BoutReal a, BoutReal b_x, BoutReal b_y, BoutReal b_z) {
+    Field3D result(a);
+    BOUT_FOR_SERIAL(i, result.getRegion("RGN_ALL")) {
+      result[i] += b_x * i.x() + b_y * i.y() + b_z * i.z();
+    }
+    return result;
+  }
+};
+
+TEST_F(BraginskiiThermalForceTest, OnlyElectrons) {
+  Options state;
+  state["species"]["e"]["density"] = 1;
+  state["species"]["e"]["temperature"] = grad1;
+  state["species"]["e"]["charge"] = -1;
+  state["species"]["e"]["AA"] = 1./1836;
+
+  component.transform(state);
+  EXPECT_FALSE(state["species"]["e"]["momentum_source"].isSet());
+}
+
+TEST_F(BraginskiiThermalForceTest, OnlyOneIon) {
+  Options state;
+  state["species"]["d+"]["density"] = 1;
+  state["species"]["d+"]["temperature"] = grad1;
+  state["species"]["d+"]["charge"] = 1;
+  state["species"]["d+"]["AA"] = 2.;
+
+  component.transform(state);
+  EXPECT_FALSE(state["species"]["d+"]["momentum_source"].isSet());
+}
+
+TEST_F(BraginskiiThermalForceTest, ElectronIonBalance) {
+  Options state;
+  state["species"]["e"]["density"] = 1;
+  state["species"]["e"]["temperature"] = grad1;
+  state["species"]["e"]["charge"] = -1;
+  state["species"]["e"]["AA"] = 1./1836;
+  state["species"]["d+"]["density"] = 1;
+  state["species"]["d+"]["temperature"] = grad1;
+  state["species"]["d+"]["charge"] = 1;
+  state["species"]["d+"]["AA"] = 2.;
+
+  component.transform(state);
+  
+  Field3D mom_e = state["species"]["e"]["momentum_source"];
+  Field3D mom_d = state["species"]["d+"]["momentum_source"];
+  BOUT_FOR_SERIAL(i, mom_e.getRegion("RGN_NOBNDRY")) {
+    // Forces on the species should be equal and opposite
+    ASSERT_FLOAT_EQ(mom_e[i], -mom_d[i]);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, IonIonBalance) {
+  Options state;
+  state["species"]["c"]["density"] = 0.01;
+  state["species"]["c"]["temperature"] = grad1;
+  state["species"]["c"]["charge"] = 1;
+  state["species"]["c"]["AA"] = 12.;
+  state["species"]["d+"]["density"] = 1;
+  state["species"]["d+"]["temperature"] = grad1;
+  state["species"]["d+"]["charge"] = 1;
+  state["species"]["d+"]["AA"] = 2.;
+
+  component.transform(state);
+  
+  Field3D mom_c = state["species"]["c"]["momentum_source"];
+  Field3D mom_d = state["species"]["d+"]["momentum_source"];
+  BOUT_FOR_SERIAL(i, mom_c.getRegion("RGN_NOBNDRY")) {
+    // Forces on the species should be equal and opposite
+    ASSERT_FLOAT_EQ(mom_c[i], -mom_d[i]);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, NoNetForce) {
+  Options state;
+  state["species"]["c"]["density"] = 0.01;
+  state["species"]["c"]["temperature"] = grad1;
+  state["species"]["c"]["charge"] = 1;
+  state["species"]["c"]["AA"] = 12.;
+  state["species"]["ar"]["density"] = 0.01;
+  state["species"]["ar"]["temperature"] = grad2;//linearGradient(0., 0., 2., 0.);
+  state["species"]["ar"]["charge"] = 1;
+  state["species"]["ar"]["AA"] = 40.;
+  state["species"]["d"]["density"] = 1;
+  state["species"]["d"]["temperature"] = grad1;
+  state["species"]["d"]["charge"] = 0;
+  state["species"]["d"]["AA"] = 2.;
+  state["species"]["d+"]["density"] = 1;
+  state["species"]["d+"]["temperature"] = grad1;//linearGradient(0., 0., 1., 0.);
+  state["species"]["d+"]["charge"] = 1;
+  state["species"]["d+"]["AA"] = 2.;
+  state["species"]["e"]["density"] = 1;
+  state["species"]["e"]["temperature"] = grad2;//linearGradient(0., 0., 2., 0.);
+  state["species"]["e"]["charge"] = -1;
+  state["species"]["e"]["AA"] = 1./1836;
+
+  component.transform(state);
+  Field3D force(0.);
+  for (const auto& [name, species] : state["species"].subsections()) {
+    if ((*species)["charge"].as<int>() != 0) {
+      force += (*species)["momentum_source"].as<Field3D>();
+    }
+  }
+  // There is no external force on plasma, so all of the thermal
+  // forces should balance out.
+  BOUT_FOR_SERIAL(i, force.getRegion("RGN_NOBNDRY")) {
+    ASSERT_FLOAT_EQ(force[i], 0.0);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, ElectronForceDensityScaling) {
+  Options state;
+  state["species"]["d1+"]["density"] = 1;
+  state["species"]["d1+"]["temperature"] = grad1;
+  state["species"]["d1+"]["charge"] = 1;
+  state["species"]["d1+"]["AA"] = 2.;
+  state["species"]["d2+"]["density"] = 2;
+  state["species"]["d2+"]["temperature"] = grad1;
+  state["species"]["d2+"]["charge"] = 1;
+  state["species"]["d2+"]["AA"] = 2.;
+  state["species"]["e"]["density"] = 1;
+  state["species"]["e"]["temperature"] = grad1;
+  state["species"]["e"]["charge"] = -1;
+  state["species"]["e"]["AA"] = 1./1836;
+
+  component.transform(state);
+  Field3D mom1 = state["species"]["d1+"]["momentum_source"], mom2 = state["species"]["d2+"]["momentum_source"];
+  BOUT_FOR_SERIAL(i, mom1.getRegion("RGN_NOBNDRY")) {
+    // Force is directly proportional to ion density
+    ASSERT_NE(mom1[i], 0.);
+    ASSERT_FLOAT_EQ(2*mom1[i], mom2[i]);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, ElectronForceChargeScaling) {
+  Options state;
+  state["species"]["d1+"]["density"] = 1;
+  state["species"]["d1+"]["temperature"] = grad1;
+  state["species"]["d1+"]["charge"] = 1;
+  state["species"]["d1+"]["AA"] = 2.;
+  state["species"]["d2+"]["density"] = 1;
+  state["species"]["d2+"]["temperature"] = grad1;
+  state["species"]["d2+"]["charge"] = 2;
+  state["species"]["d2+"]["AA"] = 2.;
+  state["species"]["e"]["density"] = 1;
+  state["species"]["e"]["temperature"] = grad1;
+  state["species"]["e"]["charge"] = -1;
+  state["species"]["e"]["AA"] = 1./1836;
+
+  component.transform(state);
+  Field3D mom1 = state["species"]["d1+"]["momentum_source"], mom2 = state["species"]["d2+"]["momentum_source"];
+  BOUT_FOR_SERIAL(i, mom1.getRegion("RGN_NOBNDRY")) {
+    // Force is proportional to square of ion density
+    ASSERT_NE(mom1[i], 0.);
+    ASSERT_FLOAT_EQ(4*mom1[i], mom2[i]);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, ElectronForceTemperatureGradScaling) {
+  Options state0, state1, state2;
+  state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["temperature"] = grad1;
+  state1["species"]["d+"]["charge"] = 1;
+  state1["species"]["d+"]["AA"] = 2.;
+  state1["species"]["e"]["density"] = 1;
+  state1["species"]["e"]["charge"] = -1;
+  state1["species"]["e"]["AA"] = 1./1836;
+
+  state0 = state1.copy();
+  state2 = state1.copy();
+
+  state0["species"]["e"]["temperature"] = grad_perp;
+  state1["species"]["e"]["temperature"] = grad1;
+  state2["species"]["e"]["temperature"] = grad2;
+
+  state1["species"]["d2+"]["density"] = 1;
+  state1["species"]["d2+"]["temperature"] = grad1;
+  state1["species"]["d2+"]["charge"] = 1;
+  state1["species"]["d2+"]["AA"] = 2.;  
+
+  component.transform(state0);
+  component.transform(state1);
+  component.transform(state2);
+  
+  Field3D mom0 = state0["species"]["d+"]["momentum_source"], mom1 = state1["species"]["d+"]["momentum_source"], mom2 = state2["species"]["d+"]["momentum_source"], mom1_prime = state1["species"]["d2+"]["momentum_source"];
+BOUT_FOR_SERIAL(i, mom1.getRegion("RGN_NOBNDRY")) {
+    // Temperature gradient of the ion doesn't influence force
+    ASSERT_FLOAT_EQ(mom1[i], mom1_prime[i]);
+    // Force is proportional to the parallel electron temperature gradient
+    ASSERT_NE(mom1[i], 0.);
+    ASSERT_FLOAT_EQ(mom0[i], 0.);
+    ASSERT_FLOAT_EQ(mom2[i], 2*mom1[i]);
+  }
+}
+
+TEST_F(BraginskiiThermalForceTest, IonIonForceTemperatureGradeScaling) {
+  Options state1, state2;
+  state1["species"]["c1"]["density"] = 0.01;
+  state1["species"]["c1"]["temperature"] = grad1;
+  state1["species"]["c1"]["charge"] = 1;
+  state1["species"]["c1"]["AA"] = 12.;
+  state1["species"]["c2"]["density"] = 0.01;
+  state1["species"]["c2"]["temperature"] = grad2;
+  state1["species"]["c2"]["charge"] = 1;
+  state1["species"]["c2"]["AA"] = 12.;
+  state1["species"]["d+"]["density"] = 1;
+  state1["species"]["d+"]["charge"] = 1;
+  state1["species"]["d+"]["AA"] = 2.;
+
+  state2 = state1.copy();
+  state1["species"]["d+"]["temperature"] = grad1;
+  state2["species"]["d+"]["temperature"] = grad2;
+
+  component.transform(state1);
+  component.transform(state2);
+
+  Field3D mom1_1 = state1["species"]["c1"]["momentum_source"], mom1_2 = state1["species"]["c2"]["momentum_source"], mom2_1 = state2["species"]["c1"]["momentum_source"], mom2_2 = state2["species"]["c2"]["momentum_source"];
+  BOUT_FOR_SERIAL(i, mom1_1.getRegion("RGN_NOBNDRY")) {
+    // Changing temperature gradient of the heavy ion should not change the force
+    EXPECT_FLOAT_EQ(mom1_1[i], mom1_2[i]);
+    EXPECT_FLOAT_EQ(mom2_1[i], mom2_2[i]);
+    // The force is proportional to the temperature gradient of the light ion
+    EXPECT_FLOAT_EQ(2*mom1_1[i], mom2_1[i]);
+  }
+}
+
+class BraginskiiThermalForceTest_MassRatio
+    : public BraginskiiThermalForceTest,
+      public testing::WithParamInterface<std::tuple<int, int, bool>> {};
+
+TEST_P(BraginskiiThermalForceTest_MassRatio, CheckForIonMasses) {
+  auto [aa1, aa2, thermal_force_present] = GetParam();
+  Options state{
+      {"species",
+       {{"M", {{"density", 1}, {"temperature", grad1}, {"charge", 1}, {"AA", aa1}}},
+        {"N", {{"density", 1}, {"temperature", grad2}, {"charge", 2}, {"AA", aa2}}}}}};
+  component.transform(state);
+  if (thermal_force_present) {
+    Field3D momentum_source1 = state["species"]["M"]["momentum_source"];
+    Field3D momentum_source2 = state["species"]["N"]["momentum_source"];
+
+    BOUT_FOR_SERIAL(i, momentum_source1.getRegion("RGN_NOBNDRY")) {
+      // The masses of the ions are different enough for thermal force to be present.
+      EXPECT_NE(momentum_source1[i], 0.);
+      EXPECT_NE(momentum_source2[i], 0.);
+    }
+  } else {
+    EXPECT_FALSE(state["species"]["M"]["momentum_source"].isSet());
+    EXPECT_FALSE(state["species"]["N"]["momentum_source"].isSet());
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(BraginskiiThermalIonMasses, BraginskiiThermalForceTest_MassRatio,
+                         testing::Values(std::make_tuple(1, 50, true), std::make_tuple(50, 1, true), std::make_tuple(3, 11, true), std::make_tuple(11, 3, true), std::make_tuple(4, 10, false), std::make_tuple(10, 4, false), std::make_tuple(5, 50, false), std::make_tuple(50, 5, false), std::make_tuple(1, 7, false), std::make_tuple(7, 1, false)));

--- a/tests/unit/test_braginskii_thermal_force.cxx
+++ b/tests/unit/test_braginskii_thermal_force.cxx
@@ -230,7 +230,7 @@ BOUT_FOR_SERIAL(i, mom1.getRegion("RGN_NOBNDRY")) {
   }
 }
 
-TEST_F(BraginskiiThermalForceTest, IonIonForceTemperatureGradeScaling) {
+TEST_F(BraginskiiThermalForceTest, IonIonForceTemperatureGradScaling) {
   Options state1, state2;
   state1["species"]["c1"]["density"] = 0.01;
   state1["species"]["c1"]["temperature"] = grad1;


### PR DESCRIPTION
This refactor the current implementation of the Braginskii closure so that it will be easier to swap it out for alternative formulations. A number of new unit tests were added before the actual refactoring began, to ensure nothing is broken.