### PR TITLE
Fixes to collision frequency selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,8 @@ if(HERMES_TESTS)
   hermes_add_integrated_test(sod-shock-energy)
   hermes_add_integrated_test(drift-wave)
   hermes_add_integrated_test(alfven-wave)
+  hermes_add_integrated_test(collfreq-braginskii-afn)
+  hermes_add_integrated_test(collfreq-multispecies)
 
   # Unit tests
   option(HERMES_UNIT_TESTS "Build the unit tests" ON)

--- a/docs/sphinx/developer.rst
+++ b/docs/sphinx/developer.rst
@@ -882,3 +882,12 @@ When collisions are neglected, we obtain the result
    :name: alfven-wave
    :alt: Alfven wave speed, as function of parallel and perpendicular wavenumbers
    :width: 60%
+
+Collision frequency selection
+~~~~~~~~~~~~~~
+
+There are two simple integrated tests to make sure that the collision frequency selection is correct
+across `neutral_mixed`, `evolve_pressure`, `ion_viscosity` and `neutral_parallel_diffusion`.
+A minimal 3D geometry is run for one RHS evaluation, and the test checks the log file
+to make sure the correct collisionalities were selected. One of the tests is for the `multispecies`
+mode across all components, while the other is for `braginskii` for plasma and `afn` for neutrals.

--- a/include/hermes_utils.hxx
+++ b/include/hermes_utils.hxx
@@ -55,9 +55,6 @@ inline T clamp(const T& var, BoutReal lo, BoutReal hi, const std::string& rgn = 
   return result;
 }
 
-// TODO: Replace the later SpeciesType with this one. This one
-// doesn't work in elec
-
 /// Enum that identifies the type of a species: electron, ion, neutral
 BOUT_ENUM_CLASS(SpeciesType, electron, ion, neutral);
 
@@ -92,21 +89,6 @@ inline bool containsAnySubstring(const std::string& mainString, const std::vecto
   return false;  // None of the substrings found
 }
 
-/// Identify species name string as electron, ion or neutral
-inline std::string identifySpeciesType(const std::string& species) {
-
-  std::string type = "";
-
-  if (species == "e") {
-    type = "electron";
-  } else if (species.find(std::string("+")) != std::string::npos) {
-    type = "ion";
-  } else {
-    type = "neutral";
-  }
-
-  return type;
-}
 
 
 /// Takes a string representing a collision, e.g. d+_e_coll

--- a/include/ion_viscosity.hxx
+++ b/include/ion_viscosity.hxx
@@ -53,7 +53,7 @@ struct IonViscosity : public Component {
 private:
   BoutReal eta_limit_alpha; ///< Flux limit coefficient
   bool perpendicular; ///< Include perpendicular flow? (Requires phi)
-  std::vector<std::string> collision_names; ///< Collisions used for collisionality
+  std::map<std::string, std::vector<std::string>> collision_names; ///< Collisions used for collisionality
   std::string viscosity_collisions_mode;  ///< Collision selection, either multispecies or braginskii
   Field3D nu;   ///< Collision frequency for conduction
   Vector2D Curlb_B; ///< Curvature vector Curl(b/B)

--- a/include/neutral_parallel_diffusion.hxx
+++ b/include/neutral_parallel_diffusion.hxx
@@ -76,7 +76,7 @@ private:
   BoutReal dneut; ///< cross-field diffusion projection (B  / Bpol)^2
 
   bool diagnose; ///< Output diagnostics?
-  std::vector<std::string> collision_names; ///< Collisions used for collisionality
+  std::map<std::string, std::vector<std::string>> collision_names; ///< Collisions used for collisionality
   std::string diffusion_collisions_mode;  ///< Collision selection, either afn or multispecies
   Field3D nu;   ///< Collision frequency for conduction
   bool equation_fix;  ///< Fix incorrect 3/2 factor in pressure advection?

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -362,16 +362,16 @@ void EvolvePressure::finally(const Options& state) {
 
           std::string collision_name = collision.second.name();
 
-          if (identifySpeciesType(species.name()) == "neutral") {
+          if (identifySpeciesTypeEnum(species.name()) == SpeciesType::neutral) {
             throw BoutException("\tBraginskii conduction collisions mode not available for neutrals, choose multispecies or afn");
-          } else if (identifySpeciesType(species.name()) == "electron") {
+          } else if (identifySpeciesTypeEnum(species.name()) == SpeciesType::electron) {
             if (/// Electron-electron collisions
                 (collisionSpeciesMatch(    
                   collision_name, species.name(), "e", "coll", "exact"))) {
                     collision_names.push_back(collision_name);
                   }
 
-          } else if (identifySpeciesType(species.name()) == "ion") {
+          } else if (identifySpeciesTypeEnum(species.name()) == SpeciesType::ion) {
             if (/// Self-collisions
                 (collisionSpeciesMatch(    
                   collision_name, species.name(), species.name(), "coll", "exact"))) {
@@ -401,7 +401,7 @@ void EvolvePressure::finally(const Options& state) {
 
           std::string collision_name = collision.second.name();
 
-          if (identifySpeciesType(species.name()) != "neutral") {
+          if (identifySpeciesTypeEnum(species.name()) != SpeciesType::neutral) {
                 throw BoutException("\tAFN conduction collisions mode not available for ions or electrons, choose braginskii or multispecies");
               }
           if (/// Charge exchange

--- a/src/neutral_parallel_diffusion.cxx
+++ b/src/neutral_parallel_diffusion.cxx
@@ -19,6 +19,10 @@ void NeutralParallelDiffusion::transform(Options& state) {
       // Skip charged species
       continue;
     }
+    // Initialise collision_names for each species if not already done
+    if (collision_names.find(species_name) == collision_names.end()) {
+      collision_names[species_name] = {};  // Initialise with empty vector
+    }
 
     const BoutReal AA = GET_VALUE(BoutReal, species["AA"]); // Atomic mass
     const Field3D Nn = GET_VALUE(Field3D, species["density"]);
@@ -29,7 +33,7 @@ void NeutralParallelDiffusion::transform(Options& state) {
     // Collisionality
     // Multispecies mode: in, en, nn, cx
     // New mode: cx, iz (in line with SOLPS AFN, Horsten 2017)
-    if (collision_names.empty()) {     /// Calculate only once - at the beginning
+    if (collision_names[species_name].empty()) {     /// Calculate only once - at the beginning
 
       if (diffusion_collisions_mode == "afn") {
         for (const auto& collision : species["collision_frequencies"].getChildren()) {
@@ -43,7 +47,7 @@ void NeutralParallelDiffusion::transform(Options& state) {
               (collisionSpeciesMatch(    
                 collision_name, species.name(), "+", "iz", "partial"))) {
                   
-                  collision_names.push_back(collision_name);
+                  collision_names[species_name].push_back(collision_name);
                 }
         }
       // Multispecies mode: all collisions and CX are included
@@ -59,7 +63,7 @@ void NeutralParallelDiffusion::transform(Options& state) {
               (collisionSpeciesMatch(    
                 collision_name, species.name(), "", "coll", "partial"))) {
                   
-                  collision_names.push_back(collision_name);
+                  collision_names[species_name].push_back(collision_name);
                 }
         }
 
@@ -67,14 +71,14 @@ void NeutralParallelDiffusion::transform(Options& state) {
         throw BoutException("\tdiffusion_collisions_mode for {:s} must be either multispecies or afn", species.name());
       }
 
-      if (collision_names.empty()) {
+      if (collision_names[species_name].empty()) {
         throw BoutException("\tNo collisions found for {:s} in neutral_parallel_diffusion for selected collisions mode", species.name());
       }
 
       /// Write chosen collisions to log file
       output_info.write("\t{:s} neutral diffusion collisionality mode: '{:s}' using ",
                       species.name(), diffusion_collisions_mode);
-      for (const auto& collision : collision_names) {        
+      for (const auto& collision : collision_names[species_name]) {        
         output_info.write("{:s} ", collision);
       }
       output_info.write("\n");
@@ -83,7 +87,7 @@ void NeutralParallelDiffusion::transform(Options& state) {
 
     /// Collect the collisionalities based on list of names
     nu = 0;
-    for (const auto& collision_name : collision_names) {
+    for (const auto& collision_name : collision_names[species_name]) {
       nu += GET_VALUE(Field3D, species["collision_frequencies"][collision_name]);
     }
 

--- a/tests/integrated/collfreq-braginskii-afn/data/BOUT.inp
+++ b/tests/integrated/collfreq-braginskii-afn/data/BOUT.inp
@@ -1,0 +1,162 @@
+nout = 0
+timestep = 1
+
+
+[mesh]
+# 1D simulation, use "y" as the dimension along the fieldline
+nx = 10
+ny = 10   # Resolution along field-line
+nz = 10
+ixseps1 = 0
+J = 1  
+
+
+[hermes]
+components = (d+, he+, he, d, e,
+              sheath_boundary_simple, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion, ion_viscosity)
+
+
+[solver]
+type = cvode           
+
+
+[sheath_boundary_simple]
+lower_y = false
+upper_y = true
+diagnose = true
+
+
+[neutral_parallel_diffusion]
+dneut = 10 
+diffusion_collisions_mode = afn
+
+
+[collisions]
+electron_ion = true
+electron_electron = true
+electron_neutral = true
+ion_ion = true
+ion_neutral = true
+neutral_neutral = true
+diagnose = true
+
+
+[ion_viscosity]
+viscosity_collisions_mode = braginskii
+
+[recycling]
+species = d+, he+
+
+
+####################################
+[d+]
+type = (evolve_density, evolve_pressure, evolve_momentum, 
+        noflow_boundary)
+
+charge = 1
+AA = 2 
+thermal_conduction = true
+conduction_collisions_mode = braginskii
+noflow_upper_y = false
+recycle_as = d
+target_recycle = true  
+diagnose = true
+
+[Nd+]
+function = 1
+
+[Pd+]
+function = 1
+
+[NVd+]
+function = 1 
+
+####################################
+[he+]  
+type = (evolve_density, evolve_pressure, evolve_momentum, 
+        noflow_boundary)
+        
+charge = 2
+AA = 4 
+thermal_conduction = true
+conduction_collisions_mode = braginskii
+noflow_upper_y = false
+recycle_as = he
+target_recycle = true  
+diagnose = true
+
+[Nhe+]
+function = 0.01
+
+[Phe+]
+function = 0.001
+
+[NVhe+]
+function = 0.001
+
+####################################
+[he]
+type = (neutral_mixed, noflow_boundary)
+
+AA = 4
+diffusion_collisions_mode = afn
+diagnose = true
+
+[Nhe]
+function = 0.001
+
+[Phe]
+function = 0.0001
+
+[NVhe]
+function = 0.0001
+
+####################################
+[d]
+type = (neutral_mixed, noflow_boundary)
+
+AA = 2
+diffusion_collisions_mode = afn
+diagnose = true
+
+[Nd]
+function = 0.001
+
+[Pd]
+function = 0.0001
+
+[NVd]
+function = 0.0001
+
+####################################
+[e] # Electrons
+type = (quasineutral, evolve_pressure, zero_current, 
+        noflow_boundary)
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+thermal_conduction = true  # in evolve_pressure
+conduction_collisions_mode = braginskii
+
+diagnose = true
+
+[Pe]
+
+function = `Pd+:function`  
+
+####################################
+
+
+[reactions]
+diagnose = true
+type = (
+        d + e -> d+ + 2e,     # Deuterium ionisation
+        d+ + e -> d,          # Deuterium recombination
+        d + d+ -> d+ + d,     # Charge exchange
+
+        he + e -> he+ + 2e,   # Helium ionisation
+        he+ + e -> he,        # Helium+ recombination
+       )

--- a/tests/integrated/collfreq-braginskii-afn/runtest
+++ b/tests/integrated/collfreq-braginskii-afn/runtest
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Python script to run and analyse MMS test
+
+from __future__ import division
+from __future__ import print_function
+
+try:
+  from builtins import str
+except:
+  pass
+
+from boututils.run_wrapper import shell, launch, getmpirun
+from boutdata.collect import collect
+
+from numpy import sqrt, max, abs, mean, array, log, concatenate
+from pathlib import Path
+
+# Remove old test results and symlink executable
+for file in ["BOUT.dmp.0.nc", "BOUT.log.0", "BOUT.restart.0.nc", "BOUT.settings", ".BOUT.pid.0"]:
+    path = Path("data/" + file)
+    if path.is_file():
+        print(f"Removing old file data/{file}")
+        path.unlink()
+
+if not Path("hermes-3").is_file():
+  shell("ln -s ../../../hermes-3 hermes-3")
+
+# Run and exit if unsuccessful
+s, out = launch("./hermes-3 -d data", nproc=1, pipe=True)
+
+if s != 0:
+  print(" => Test failed: ")
+  print(out)
+  exit(1)
+
+# Save output to log file
+with open("run.log", "w") as f:
+  f.write(out)
+
+# Check log for success/failure
+success = True
+collisionality_lines = []
+
+# Check for exceptions and collect collision selections
+with open("run.log", "r") as f:
+  lines = f.readlines()
+  for i, line in enumerate(lines):
+    if "====== Exception thrown ======" in line:
+        success = False
+        message = lines[i+1]
+        
+    if "collisionality mode" in line:
+      collisionality_lines.append(line.strip())
+        
+# Check that expected collisions were chosen
+expected_lines = [
+	"d neutral diffusion collisionality mode: 'afn' using d_d+_cx d_d+_iz", 
+	"he neutral diffusion collisionality mode: 'afn' using he_he+_iz", 
+	"d+ viscosity collisionality mode: 'braginskii' using d+_d+_coll d+_he+_coll", 
+	"he+ viscosity collisionality mode: 'braginskii' using he+_d+_coll he+_he+_coll", 
+	"d+ conduction collisionality mode: 'braginskii' using d+_d+_coll", 
+	"he+ conduction collisionality mode: 'braginskii' using he+_he+_coll", 
+	"he neutral collisionality mode: 'afn' using he_he+_iz he_he_coll", 
+	"d neutral collisionality mode: 'afn' using d_d+_cx d_d+_iz d_d_coll", 
+	"e conduction collisionality mode: 'braginskii' using e_e_coll", 
+]
+
+for line in expected_lines:
+  if line not in collisionality_lines:
+    success = False
+    message = f"Did not find expected collisionality line:\n{line}"
+        
+# Final output
+if success:
+  print(" => Test passed")
+  exit(0)
+else:
+  print(f" => Test failed: \n{message}")
+  exit(1)

--- a/tests/integrated/collfreq-multispecies/data/BOUT.inp
+++ b/tests/integrated/collfreq-multispecies/data/BOUT.inp
@@ -1,0 +1,162 @@
+nout = 0
+timestep = 1
+
+
+[mesh]
+# 1D simulation, use "y" as the dimension along the fieldline
+nx = 10
+ny = 10   # Resolution along field-line
+nz = 10
+ixseps1 = 0
+J = 1  
+
+
+[hermes]
+components = (d+, he+, he, d, e,
+              sheath_boundary_simple, collisions, recycling, reactions,
+              electron_force_balance, neutral_parallel_diffusion, ion_viscosity)
+
+
+[solver]
+type = cvode           
+
+
+[sheath_boundary_simple]
+lower_y = false
+upper_y = true
+diagnose = true
+
+
+[neutral_parallel_diffusion]
+dneut = 10 
+diffusion_collisions_mode = multispecies
+
+
+[collisions]
+electron_ion = true
+electron_electron = true
+electron_neutral = true
+ion_ion = true
+ion_neutral = true
+neutral_neutral = true
+diagnose = true
+
+
+[ion_viscosity]
+viscosity_collisions_mode = multispecies
+
+[recycling]
+species = d+, he+
+
+
+####################################
+[d+]
+type = (evolve_density, evolve_pressure, evolve_momentum, 
+        noflow_boundary)
+
+charge = 1
+AA = 2 
+thermal_conduction = true
+conduction_collisions_mode = multispecies
+noflow_upper_y = false
+recycle_as = d
+target_recycle = true  
+diagnose = true
+
+[Nd+]
+function = 1
+
+[Pd+]
+function = 1
+
+[NVd+]
+function = 1 
+
+####################################
+[he+]  
+type = (evolve_density, evolve_pressure, evolve_momentum, 
+        noflow_boundary)
+        
+charge = 2
+AA = 4 
+thermal_conduction = true
+conduction_collisions_mode = multispecies
+noflow_upper_y = false
+recycle_as = he
+target_recycle = true  
+diagnose = true
+
+[Nhe+]
+function = 0.01
+
+[Phe+]
+function = 0.001
+
+[NVhe+]
+function = 0.001
+
+####################################
+[he]
+type = (neutral_mixed, noflow_boundary)
+
+AA = 4
+diffusion_collisions_mode = multispecies
+diagnose = true
+
+[Nhe]
+function = 0.001
+
+[Phe]
+function = 0.0001
+
+[NVhe]
+function = 0.0001
+
+####################################
+[d]
+type = (neutral_mixed, noflow_boundary)
+
+AA = 2
+diffusion_collisions_mode = multispecies
+diagnose = true
+
+[Nd]
+function = 0.001
+
+[Pd]
+function = 0.0001
+
+[NVd]
+function = 0.0001
+
+####################################
+[e] # Electrons
+type = (quasineutral, evolve_pressure, zero_current, 
+        noflow_boundary)
+
+noflow_upper_y = false
+
+charge = -1
+AA = 1/1836
+thermal_conduction = true  # in evolve_pressure
+conduction_collisions_mode = multispecies
+
+diagnose = true
+
+[Pe]
+
+function = `Pd+:function`  
+
+####################################
+
+
+[reactions]
+diagnose = true
+type = (
+        d + e -> d+ + 2e,     # Deuterium ionisation
+        d+ + e -> d,          # Deuterium recombination
+        d + d+ -> d+ + d,     # Charge exchange
+
+        he + e -> he+ + 2e,   # Helium ionisation
+        he+ + e -> he,        # Helium+ recombination
+       )

--- a/tests/integrated/collfreq-multispecies/runtest
+++ b/tests/integrated/collfreq-multispecies/runtest
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Python script to run and analyse MMS test
+
+from __future__ import division
+from __future__ import print_function
+
+try:
+  from builtins import str
+except:
+  pass
+
+from boututils.run_wrapper import shell, launch, getmpirun
+from boutdata.collect import collect
+
+from numpy import sqrt, max, abs, mean, array, log, concatenate
+from pathlib import Path
+
+# Remove old test results and symlink executable
+for file in ["BOUT.dmp.0.nc", "BOUT.log.0", "BOUT.restart.0.nc", "BOUT.settings", ".BOUT.pid.0"]:
+    path = Path("data/" + file)
+    if path.is_file():
+        print(f"Removing old file data/{file}")
+        path.unlink()
+
+if not Path("hermes-3").is_file():
+  shell("ln -s ../../../hermes-3 hermes-3")
+
+# Run and exit if unsuccessful
+s, out = launch("./hermes-3 -d data", nproc=1, pipe=True)
+
+if s != 0:
+  print(" => Test failed: ")
+  print(out)
+  exit(1)
+
+# Save output to log file
+with open("run.log", "w") as f:
+  f.write(out)
+
+# Check log for success/failure
+success = True
+collisionality_lines = []
+
+# Check for exceptions and collect collision selections
+with open("run.log", "r") as f:
+  lines = f.readlines()
+  for i, line in enumerate(lines):
+    if "====== Exception thrown ======" in line:
+        success = False
+        message = lines[i+1]
+        
+    if "collisionality mode" in line:
+      collisionality_lines.append(line.strip())
+        
+# Check that expected collisions were chosen
+expected_lines = [
+  "d neutral diffusion collisionality mode: 'multispecies' using d_d+_coll d_d+_cx d_d_coll d_e_coll d_he+_coll d_he_coll",
+	"he neutral diffusion collisionality mode: 'multispecies' using he_d+_coll he_d_coll he_e_coll he_he+_coll he_he_coll",
+	"d+ viscosity collisionality mode: 'multispecies' using d+_d+_coll d+_d_coll d+_d_cx d+_e_coll d+_he+_coll d+_he_coll",
+	"he+ viscosity collisionality mode: 'multispecies' using he+_d+_coll he+_d_coll he+_e_coll he+_he+_coll he+_he_coll",
+	"d+ conduction collisionality mode: 'multispecies' using d+_d+_coll d+_d_coll d+_d_cx d+_e_coll d+_he+_coll d+_he_coll",
+	"he+ conduction collisionality mode: 'multispecies' using he+_d+_coll he+_d_coll he+_e_coll he+_he+_coll he+_he_coll",
+	"he neutral collisionality mode: 'multispecies' using he_d+_coll he_d_coll he_e_coll he_he+_coll he_he_coll",
+	"d neutral collisionality mode: 'multispecies' using d_d+_coll d_d+_cx d_d_coll d_e_coll d_he+_coll d_he_coll",
+	"e conduction collisionality mode: 'multispecies' using e_d+_coll e_d_coll e_e_coll e_he+_coll e_he_coll",
+]
+
+for line in expected_lines:
+  if line not in collisionality_lines:
+    success = False
+    message = f"Did not find expected collisionality line:\n{line}"
+        
+# Final output
+if success:
+  print(" => Test passed")
+  exit(0)
+else:
+  print(f" => Test failed: \n{message}")
+  exit(1)


### PR DESCRIPTION
- [ ] Fixes for `ion_viscosity` and `neutral_parallel_diffusion` which didn't have collision frequency properly implemented - the logic didn't account for the fact these are top level components and iterate over species, and broke with multiple main ions. Solves https://github.com/boutproject/hermes-3/issues/401

- [ ] Change `IdentifySpeciesType` to `IdentifySpeciesTypeEnum`, which allows ions to be named `i`. Solves https://github.com/boutproject/hermes-3/issues/400. I think we shouldn't allow names like `i` because they break reactions, see https://github.com/boutproject/hermes-3/issues/405.

- [ ] Update `evolve_energy` collision frequency logic to match that of `evolve_pressure`. I think `evolve_pressure` was improved but the fixes were never propagated to `evolve_energy`.

- [ ] Add two integrated tests + docs. They ensure collision frequency selection is correct with multiple main ions for both the `multispecies` and `braginskii`/`afn` modes. Components tested: `evolve_pressure`, `ion_viscosity`, `neutral_parallel_diffusion`, `neutral_mixed`. I am not including `evolve_energy` because it's not commonly used, and because there is an ongoing refactor to pull conduction out.


