### PR TITLE
Fixes for components, species list

### DIFF
--- a/include/component.hxx
+++ b/include/component.hxx
@@ -54,8 +54,8 @@ struct SpeciesInformation {
       } else {
         throw BoutException("Species {} has unrecognised type {}", sp, toString(type));
       }
-      finish_construction();
     }
+    finish_construction();
   }
 
   std::vector<std::string> electrons, neutrals, positive_ions, negative_ions, ions,

--- a/src/component.cxx
+++ b/src/component.cxx
@@ -9,10 +9,9 @@
 #include "../include/guarded_options.hxx"
 #include "../include/permissions.hxx"
 
-std::unique_ptr<Component> Component::create(const std::string &type,
-                                             const std::string &name,
-                                             Options &alloptions,
-                                             Solver *solver) {
+std::unique_ptr<Component> Component::create(const std::string& type,
+                                             const std::string& name, Options& alloptions,
+                                             Solver* solver) {
 
   return ComponentFactory::getInstance().create(type, name, alloptions, solver);
 }
@@ -32,24 +31,24 @@ void Component::transform(Options& state) {
 #endif
 }
 
-void Component::declareAllSpecies(const SpeciesInformation & info) {
-    state_variable_access.substitute("electrons", info.electrons);
-    state_variable_access.substitute("electrons2", info.electrons);
-    state_variable_access.substitute("neutrals", info.neutrals);
-    state_variable_access.substitute("neutrals2", info.neutrals);
-    state_variable_access.substitute("positive_ions", info.positive_ions);
-    state_variable_access.substitute("positive_ions2", info.positive_ions);
-    state_variable_access.substitute("negative_ions", info.negative_ions);
-    state_variable_access.substitute("negative_ions2", info.negative_ions);
-    state_variable_access.substitute("ions", info.ions);
-    state_variable_access.substitute("ions2", info.ions);
-    state_variable_access.substitute("charged", info.charged);
-    state_variable_access.substitute("charged", info.charged);
-    state_variable_access.substitute("non_electrons", info.non_electrons);
-    state_variable_access.substitute("non_electrons2", info.non_electrons);
-    state_variable_access.substitute("all_species", info.all_species);
-    state_variable_access.substitute("all_species2", info.all_species);
-    state_variable_access.checkNoRemainingSubstitutions();
+void Component::declareAllSpecies(const SpeciesInformation& info) {
+  state_variable_access.substitute("electrons", info.electrons);
+  state_variable_access.substitute("electrons2", info.electrons);
+  state_variable_access.substitute("neutrals", info.neutrals);
+  state_variable_access.substitute("neutrals2", info.neutrals);
+  state_variable_access.substitute("positive_ions", info.positive_ions);
+  state_variable_access.substitute("positive_ions2", info.positive_ions);
+  state_variable_access.substitute("negative_ions", info.negative_ions);
+  state_variable_access.substitute("negative_ions2", info.negative_ions);
+  state_variable_access.substitute("ions", info.ions);
+  state_variable_access.substitute("ions2", info.ions);
+  state_variable_access.substitute("charged", info.charged);
+  state_variable_access.substitute("charged2", info.charged);
+  state_variable_access.substitute("non_electrons", info.non_electrons);
+  state_variable_access.substitute("non_electrons2", info.non_electrons);
+  state_variable_access.substitute("all_species", info.all_species);
+  state_variable_access.substitute("all_species2", info.all_species);
+  state_variable_access.checkNoRemainingSubstitutions();
 }
 
 constexpr decltype(ComponentFactory::type_name) ComponentFactory::type_name;
@@ -66,12 +65,12 @@ bool isSetFinal(const Options& option, [[maybe_unused]] const std::string& locat
   return option.isSet();
 }
 
-bool isSetFinal(const GuardedOptions & option, [[maybe_unused]] const std::string& location) {
+bool isSetFinal(const GuardedOptions& option,
+                [[maybe_unused]] const std::string& location) {
   const bool set = option.isSet();
 #if CHECKLEVEL >= 1
   const PermissionTypes perm = option.getHighestPermission();
-  if (perm >= PermissionTypes::Read
-      or (perm == PermissionTypes::ReadIfSet and set)) {
+  if (perm >= PermissionTypes::Read or (perm == PermissionTypes::ReadIfSet and set)) {
     const Options& opt = option.get();
     const_cast<Options&>(opt).attributes["final"] = location;
     const_cast<Options&>(opt).attributes["final-domain"] = location;
@@ -80,8 +79,8 @@ bool isSetFinal(const GuardedOptions & option, [[maybe_unused]] const std::strin
   return set;
 }
 
-
-bool isSetFinalNoBoundary(const Options& option, [[maybe_unused]] const std::string& location) {
+bool isSetFinalNoBoundary(const Options& option,
+                          [[maybe_unused]] const std::string& location) {
 #if CHECKLEVEL >= 1
   // Mark option as final inside the domain, but not in the boundary
   const_cast<Options&>(option).attributes["final-domain"] = location;
@@ -89,7 +88,8 @@ bool isSetFinalNoBoundary(const Options& option, [[maybe_unused]] const std::str
   return option.isSet();
 }
 
-bool isSetFinalNoBoundary(const GuardedOptions & option, [[maybe_unused]] const std::string& location) {
+bool isSetFinalNoBoundary(const GuardedOptions& option,
+                          [[maybe_unused]] const std::string& location) {
   const bool set = option.isSet();
 #if CHECKLEVEL >= 1
   const PermissionTypes perm = option.getHighestPermission(Regions::Interior);

--- a/src/component_scheduler.cxx
+++ b/src/component_scheduler.cxx
@@ -9,9 +9,8 @@
 #include "../include/component.hxx"
 #include "../include/component_scheduler.hxx"
 
-ComponentScheduler::ComponentScheduler(Options &scheduler_options,
-                                       Options &component_options,
-                                       Solver *solver) {
+ComponentScheduler::ComponentScheduler(Options& scheduler_options,
+                                       Options& component_options, Solver* solver) {
 
   const std::string component_names = scheduler_options["components"]
                                           .doc("Components in order of execution")
@@ -23,7 +22,7 @@ ComponentScheduler::ComponentScheduler(Options &scheduler_options,
   std::vector<std::string> negative_ions;
 
   // For now split on ','. Something like "->" might be better
-  for (const auto &name : strsplit(component_names, ',')) {
+  for (const auto& name : strsplit(component_names, ',')) {
     // Ignore brackets, to allow these to be used to span lines.
     // In future brackets may be useful for complex scheduling
 
@@ -32,7 +31,7 @@ ComponentScheduler::ComponentScheduler(Options &scheduler_options,
       continue;
     }
 
-    if (name_trimmed == "e" or name == "ebeam") {
+    if (name_trimmed == "e" or name_trimmed == "ebeam") {
       electrons.push_back(name_trimmed);
     }
     // FIXME: Would there be any spcies without AA? Is there any other
@@ -59,61 +58,58 @@ ComponentScheduler::ComponentScheduler(Options &scheduler_options,
             ? component_options[name_trimmed]["type"].as<std::string>()
             : name_trimmed;
 
-    for (const auto &type : strsplit(types, ',')) {
+    for (const auto& type : strsplit(types, ',')) {
       auto type_trimmed = trim(type, " \t\r()");
       if (type_trimmed.empty()) {
         continue;
       }
 
-      components.push_back(Component::create(type_trimmed,
-                                             name_trimmed,
-                                             component_options,
-                                             solver));
+      components.push_back(
+          Component::create(type_trimmed, name_trimmed, component_options, solver));
     }
   }
 
   const SpeciesInformation species(electrons, neutrals, positive_ions, negative_ions);
-    
+
   for (auto& component : components) {
     component->declareAllSpecies(species);
   }
 }
 
-std::unique_ptr<ComponentScheduler> ComponentScheduler::create(Options &scheduler_options,
-                                                               Options &component_options,
-                                                               Solver *solver) {
-  return std::make_unique<ComponentScheduler>(scheduler_options,
-                                              component_options, solver);
+std::unique_ptr<ComponentScheduler> ComponentScheduler::create(Options& scheduler_options,
+                                                               Options& component_options,
+                                                               Solver* solver) {
+  return std::make_unique<ComponentScheduler>(scheduler_options, component_options,
+                                              solver);
 }
 
-
-void ComponentScheduler::transform(Options &state) {
+void ComponentScheduler::transform(Options& state) {
   // Run through each component
-  for(auto &component : components) {
+  for (auto& component : components) {
     component->transform(state);
   }
   // Enable components to update themselves based on the final state
-  for(auto &component : components) {
+  for (auto& component : components) {
     component->finally(state);
   }
 }
 
-void ComponentScheduler::outputVars(Options &state) {
+void ComponentScheduler::outputVars(Options& state) {
   // Run through each component
-  for(auto &component : components) {
+  for (auto& component : components) {
     component->outputVars(state);
   }
 }
 
-void ComponentScheduler::restartVars(Options &state) {
+void ComponentScheduler::restartVars(Options& state) {
   // Run through each component
-  for(auto &component : components) {
+  for (auto& component : components) {
     component->restartVars(state);
   }
 }
 
-void ComponentScheduler::precon(const Options &state, BoutReal gamma) {
-  for(auto &component : components) {
+void ComponentScheduler::precon(const Options& state, BoutReal gamma) {
+  for (auto& component : components) {
     component->precon(state, gamma);
   }
 }


### PR DESCRIPTION
Three fixes found by Codex:
component.hxx SpeciesInformation called finish_construction multiple times
```
-      finish_construction();
     }
+    finish_construction();
```

component.cxx declareAllSpecies substituted "charged" twice rather than substituting "charged2"
```
-    state_variable_access.substitute("charged", info.charged);
+    state_variable_access.substitute("charged2", info.charged);
```

component_scheduler.cxx ComponentScheduler used "name" rather than "name_trimmed" in comparison
```
-    if (name_trimmed == "e" or name == "ebeam") {
+    if (name_trimmed == "e" or name_trimmed == "ebeam") {
```

Mostly formatting due to touching component.cxx