### PR TITLE
Numerical method choices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,12 +412,20 @@ endif()
 
 # Compile-time options
 
-set(SLOPE_LIMITERS MinMod MC Upwind Superbee VanAlbada WENO3)
+set(SLOPE_LIMITERS MC VanAlbada WENO3 MinMod Upwind Superbee)
 set(HERMES_SLOPE_LIMITER
     MC
     CACHE STRING "Set advection slope limiter")
 set_property(CACHE HERMES_SLOPE_LIMITER PROPERTY STRINGS ${SLOPE_LIMITERS})
 message(STATUS "Slope limiter: ${HERMES_SLOPE_LIMITER}")
+
+set(CONDUCTION_METHODS Original ProductJK Harmonic)
+set(HERMES_CONDUCTION_METHOD
+    Original
+    CACHE STRING "Parallel conduction method")
+set_property(CACHE HERMES_CONDUCTION_METHOD PROPERTY STRINGS
+                                                     ${CONDUCTION_METHODS})
+message(STATUS "Conduction method: ${HERMES_CONDUCTION_METHOD}")
 
 # Generate the build config header
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ endif()
 
 # Compile-time options
 
-set(SLOPE_LIMITERS MinMod MC Upwind Superbee)
+set(SLOPE_LIMITERS MinMod MC Upwind Superbee VanAlbada WENO3)
 set(HERMES_SLOPE_LIMITER
     MC
     CACHE STRING "Set advection slope limiter")

--- a/docs/sphinx/solver_numerics.rst
+++ b/docs/sphinx/solver_numerics.rst
@@ -9,7 +9,7 @@ Solvers
 
 While Hermes-3 has access to any solver within BOUT++ (`see the long
 list in the documentation <https://
-bout-dev.readthedocs.io/en/stable/user_docs/time_integration.html>`__), 
+bout-dev.readthedocs.io/en/stable/user_docs/time_integration.html>`__),
 the development and optimisation efforts focuses on two solvers:
 
 CVODE
@@ -21,28 +21,28 @@ CVODE
    in time as possible and take long timesteps. Please
    see the `developer page <https://computing.llnl.gov/
    projects/sundials/cvode>`__ for details. CVODE is required for 3D
-   turbulence simulations and currently gives better results in 2D 
+   turbulence simulations and currently gives better results in 2D
    simulations. `The BOUT++ implementation is here. <https
    ://github.com/mikekryjak/BOUT-dev/blob/master/src/solver/impls/cvode/cvode.cxx>`__
 
 beuler
    A first-order in time implementation of the backward Euler method.
-   This is implemented using the `SNES <https://petsc.org/release/manual/snes/>`__ 
-   nonlinear solver in `PETSc <https://petsc.org/release/>`__, and 
+   This is implemented using the `SNES <https://petsc.org/release/manual/snes/>`__
+   nonlinear solver in `PETSc <https://petsc.org/release/>`__, and
    currently uses a GMRES linear solver and an ILU-type preconditioner
-   in `hypre <https://hypre.readthedocs.io/en/latest/ch-intro.html>`__. 
+   in `hypre <https://hypre.readthedocs.io/en/latest/ch-intro.html>`__.
    The algebraic preconditioner allows for extreme speedups over CVODE,
    and can already be used in 1D with good results. 2D performance is
-   highly mixed and still in development. 3D use is not feasible as the 
+   highly mixed and still in development. 3D use is not feasible as the
    matrix size precludes the use of algebraic preconditioners.
    Due to its first order nature, it will be less accurate for time-dependent
    problems, and it is mostly intended to solve for steady-state problems.
    `The BOUT++ implementation is here. <https://github.com/mikekryjak/
-   BOUT-dev/blob/master/src/solver/impls/snes/snes.cxx>`__. See the 
+   BOUT-dev/blob/master/src/solver/impls/snes/snes.cxx>`__. See the
    higher level BOUT++ PETSc implementation `here <https://github.com
    /mikekryjak/BOUT-dev/blob/master/src/solver/impls/petsc/petsc.cxx>`__.
 
-Both CVODE and beuler have an adaptive timestepper and will take as long a 
+Both CVODE and beuler have an adaptive timestepper and will take as long a
 timestep as the Newton iteration failure rate will allow.
 
 Configuring CVODE
@@ -71,11 +71,11 @@ mxorder = 3
    for preventing the solver from getting "stuck" at high order with a
    small timestep. You can alternatively set ``stablimdet = true`` to
    enable automatic `stability limit detection <https://sundials.readthedocs
-   .io/en/latest/cvode/Mathematics_link.html#cvode-mathematics-stablimit>`__ 
+   .io/en/latest/cvode/Mathematics_link.html#cvode-mathematics-stablimit>`__
    to prevent this.
 
 atol = 1e-7
-   Absolute tolerance for the solver. This is the maximum absolute error 
+   Absolute tolerance for the solver. This is the maximum absolute error
    allowed and is required to ensure accuracy/stability when variables are small.
    Available in all solvers.
 
@@ -105,9 +105,9 @@ Hypre Euclid preconditioner:
 
 
 There is an additional option ``stol`` which allows the Newton iteration
-to "converge" if the simulation has only changed by a small amount. 
-This enables the simulation to iterate almost instantly if it detects that the 
-results aren't changing. 
+to "converge" if the simulation has only changed by a small amount.
+This enables the simulation to iterate almost instantly if it detects that the
+results aren't changing.
 
 PETSc can print quite extensive performance diagnostics. These can be enabled
 by putting in the BOUT.inp options file:
@@ -120,18 +120,18 @@ by putting in the BOUT.inp options file:
 This section can also be used to set other PETSc flags, just omitting
 the leading ``-`` from the PETSc option.
 
-   
+
 
 Numerics
 ------------------------------
 
-Slope (flux) limiters 
+Slope (flux) limiters
 ~~~~~~~~~~~~~~~~~~~~~
 
 The choice of slope limiter is important: a dissipative limiter increases
 numerical dissipation but can substantially improve solver stability and
-robustness. See :ref:`sec-slope-limiter-settings` for how to change the 
-limiter. The default is ``MC``, which has a good balance between 
+robustness. See :ref:`sec-slope-limiter-settings` for how to change the
+limiter. The default is ``MC``, which has a good balance between
 stability and accuracy.
 
 Dynamics parallel to the magnetic field are solved using a 2nd-order
@@ -144,9 +144,35 @@ velocity in the direction of the magnetic field, and is aligned with
 one of the mesh coordinate directions.  All quantities are cell
 centered.
 
-Cell edge values are by default reconstructed using a MinMod method
-(other limiters are available, including 1st-order upwind, Monotonized
-Central, and Superbee). If :math:`f_i` is the value of field :math:`f` at the
+Cell edge values are reconstructed using a configurable limiter. The
+available compile-time choices of ``HERMES_SLOPE_LIMITER`` are:
+
+``MC``
+   Monotonised central second-order limiter. This is the default.
+
+``VanAlbada``
+   Symmetric second-order limiter using a smooth approximation to the
+   usual limiter switch. This is often friendlier to nonlinear solvers
+   and finite-difference Jacobian calculations because the reconstruction
+   remains differentiable at extrema.
+
+``WENO3``
+   Third-order Jiang-Shu WENO reconstruction on the same three-point stencil.
+   This is generally smoother and less dissipative than TVD limiters, but it
+   does not enforce strict monotonicity.
+
+``MinMod``
+   More dissipative second-order TVD limiter.
+
+``Upwind``
+   First-order upwind reconstruction. This is the most dissipative, but is
+   sometimes useful for robustness tests.
+
+``Superbee``
+   Aggressive second-order TVD limiter with reduced diffusion in sharp fronts,
+   but it can be less robust.
+
+If :math:`f_i` is the value of field :math:`f` at the
 center of cell :math:`i`, then using MinMod slope limiter the gradient :math:`g_i`
 inside the cell is:
 
@@ -199,6 +225,47 @@ The divergence of the flux, and so the rate of change of :math:`f` in cell
 
    \nabla\cdot\left(\mathbf{b} f v_{||}\right)_{i} = \frac{1}{V_i}\left[\frac{A_{i} + A_{i+1}}{2}\Gamma_{f, i+1/2} - \frac{A_{i-1} + A_{i}}{2}\Gamma_{f, i-1/2}\right]
 
+.. _sec-slope-limiter-settings:
+
+Selecting slope limiter and conduction method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Hermes-3 selects both the parallel advection slope limiter and the
+``Div_par_K_Grad_par_mod`` conduction discretisation at compile time
+through CMake cache options:
+
+.. code-block:: bash
+
+   cmake -S . -B build \
+     -DHERMES_SLOPE_LIMITER=MC \
+     -DHERMES_CONDUCTION_METHOD=Original
+
+``HERMES_SLOPE_LIMITER``
+   Available values are ``MC``, ``VanAlbada``, ``WENO3``, ``MinMod``,
+   ``Upwind``, and ``Superbee``.
+
+``HERMES_CONDUCTION_METHOD``
+   Selects the parallel heat conduction discretisation used in
+   :cpp:func:`Div_par_K_Grad_par_mod`. Available values are:
+
+   ``Original``
+      Separately averages :math:`K`, :math:`J`, :math:`g_{22}`, and
+      :math:`dy` at the face and then multiplies them together.
+
+   ``ProductJK``
+      Uses the same stencil as ``Original`` but averages :math:`J K`
+      together before applying the face gradient.
+
+   ``Harmonic``
+      Uses a harmonic average of the half-cell conductances
+      :math:`K J / (g_{22} dy)`. This better matches a series-resistance
+      interpretation of two adjacent half-cells and can give noticeably
+      different results when coefficients or cell sizes vary strongly.
+
+The selected values are reported at startup in the Hermes-3 log and are
+also recorded in the options tree as ``slope_limiter`` and
+``conduction_method``.
+
 Controlling Lax flux strength with sound_speed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -208,14 +275,14 @@ Controlling Lax flux strength with sound_speed
 
 By default, the Lax flux strength is calculated based on the sound speed
 of each species individually. Instead, the ``sound_speed`` component can be used
-component to sum the pressure of all species and divide by the sum of the mass density 
+component to sum the pressure of all species and divide by the sum of the mass density
 of all species:
 
 .. math::
-   
+
    c_s = \sqrt{\sum_i P_i / \sum_i m_in_i}
 
-This is set in the state as `sound_speed`. It is highly recommended to use 
+This is set in the state as `sound_speed`. It is highly recommended to use
 this when evolving electron momentum, as the electrons will represent the fastest
 sound speed in the system, increasing the amount of numerical damping from the Lax flux.
 This is enabled by default.
@@ -251,5 +318,3 @@ layers that can form:
    \Gamma_{nv, i+1/2}^{boundary} = n_{i,R}v_{||i,R}v_{||i+1/2} + a_{max}\left[n_{i,R}v_{||i,R} - n_{i+1/2}v_{||i+1/2}\right]
 
 where :math:`n_{i+1/2} = \frac{1}{2}\left(n_{i} + n_{i+1}\right)`.
-
-

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -96,8 +96,8 @@ BOUT_OVERRIDE_DEFAULT_OPTION("mesh:calcParallelSlices_on_communicate", false);
 class DecayLengthBoundary : public BoundaryOp {
 public:
   DecayLengthBoundary() : gen(nullptr) {}
-  DecayLengthBoundary(BoundaryRegion* region,  std::shared_ptr<FieldGenerator> g)
-    : BoundaryOp(region), gen(std::move(g)) {}
+  DecayLengthBoundary(BoundaryRegion* region, std::shared_ptr<FieldGenerator> g)
+      : BoundaryOp(region), gen(std::move(g)) {}
 
   using BoundaryOp::clone;
   /// Create a copy of this boundary condition
@@ -118,10 +118,11 @@ public:
     ASSERT1(mesh == f.getMesh());
 
     // Get cell radial length
-    Coordinates *coord = mesh->getCoordinates();
+    Coordinates* coord = mesh->getCoordinates();
     Field2D dx = coord->dx;
     Field2D g11 = coord->g11;
-    Field2D dr = dx / sqrt(g11); // cell radial length. dr = dx/(Bpol * R) and g11 = (Bpol*R)**2 
+    Field2D dr =
+        dx / sqrt(g11); // cell radial length. dr = dx/(Bpol * R) and g11 = (Bpol*R)**2
 
     // Only implemented for cell centre quantities
     ASSERT1(f.getLocation() == CELL_CENTRE);
@@ -129,11 +130,13 @@ public:
     // This loop goes over the first row of boundary cells (in X and Y)
     for (bndry->first(); !bndry->isDone(); bndry->next1d()) {
       for (int zk = 0; zk < mesh->LocalNz; zk++) { // Loop over Z points
-        BoutReal decay_length = 3; // Default decay length is 3 normalised units (usually ~3mm)
+        BoutReal decay_length =
+            3; // Default decay length is 3 normalised units (usually ~3mm)
         if (gen) {
           // Pick up the boundary condition setting from the input file
           // Must be specified in normalised units like the other BCs inputs
-          decay_length = gen->generate(bout::generator::Context(bndry, zk, CELL_CENTRE, 0.0, mesh));
+          decay_length =
+              gen->generate(bout::generator::Context(bndry, zk, CELL_CENTRE, 0.0, mesh));
         }
         // Set value in inner guard cell f(bndry->x, bndry->y, zk)
         // using the final domain cell value f(bndry->x - bndry->bx, bndry->y - bndry->by, zk)
@@ -142,19 +145,21 @@ public:
         //    (-1, 0) X inner boundary (Core or PF)
         //    (0, 1)  Y upper boundary (outer lower target)
         //    (0, -1) Y lower boundary (inner lower target)
-        
-        // Distance between final cell centre and inner guard cell centre in normalised units
-        BoutReal distance = 0.5 * (dr(bndry->x, bndry->y) + 
-          dr(bndry->x - bndry->bx, bndry->y - bndry->by));
 
-        // Exponential decay 
-        f(bndry->x, bndry->y, zk) =
-          f(bndry->x - bndry->bx, bndry->y - bndry->by, zk) * exp(-1 * distance / decay_length);
+        // Distance between final cell centre and inner guard cell centre in normalised units
+        BoutReal distance =
+            0.5
+            * (dr(bndry->x, bndry->y) + dr(bndry->x - bndry->bx, bndry->y - bndry->by));
+
+        // Exponential decay
+        f(bndry->x, bndry->y, zk) = f(bndry->x - bndry->bx, bndry->y - bndry->by, zk)
+                                    * exp(-1 * distance / decay_length);
 
         // Set any remaining guard cells (i.e. the outer guards) to the same value
         // Should the outer guards have the decay continue, or just copy what the inners have?
         for (int i = 1; i < bndry->width; i++) {
-          f(bndry->x + i * bndry->bx, bndry->y + i * bndry->by, zk) = f(bndry->x, bndry->y, zk);
+          f(bndry->x + i * bndry->bx, bndry->y + i * bndry->by, zk) =
+              f(bndry->x, bndry->y, zk);
         }
       }
     }
@@ -170,8 +175,8 @@ private:
 
 int Hermes::init(bool restarting) {
 
-  auto &options = Options::root()["hermes"];
-  
+  auto& options = Options::root()["hermes"];
+
   output.write("\nGit Version of Hermes: {:s}\n", hermes::version::revision);
   options["revision"] = hermes::version::revision;
   options["revision"].setConditionallyUsed();
@@ -179,6 +184,9 @@ int Hermes::init(bool restarting) {
   output.write("Slope limiter: {}\n", hermes::limiter_typename);
   options["slope_limiter"] = hermes::limiter_typename;
   options["slope_limiter"].setConditionallyUsed();
+  output.write("Conduction method: {}\n", hermes::conduction_typename);
+  options["conduction_method"] = hermes::conduction_typename;
+  options["conduction_method"].setConditionallyUsed();
 
   // Choose normalisations
   Tnorm = options["Tnorm"].doc("Reference temperature [eV]").withDefault(100.);
@@ -193,7 +201,7 @@ int Hermes::init(bool restarting) {
   units["inv_meters_cubed"] = Nnorm;
   units["eV"] = Tnorm;
   units["Tesla"] = Bnorm;
-  units["seconds"] = 1./Omega_ci;
+  units["seconds"] = 1. / Omega_ci;
   units["meters"] = rho_s0;
 
   // Put into the options tree, so quantities can be normalised
@@ -212,11 +220,13 @@ int Hermes::init(bool restarting) {
   TRACE("Loading metric tensor");
 
   if (options.isSet("loadmetric")) {
-    throw BoutException("Error: The loadmetric option has been renamed to recalculate_metric.\n"
-                        "Note: The default (true/false) is inverted for the new option.\n"
-                        "Setting recalculate_metric=false (the default) uses the metric in the grid file.\n"
-                        "Setting recalculate_metric=true loads Rxy, Bpxy etc from the grid file.\n"
-                        "  This assumes an orthogonal coordinate system. See manual for details.");
+    throw BoutException(
+        "Error: The loadmetric option has been renamed to recalculate_metric.\n"
+        "Note: The default (true/false) is inverted for the new option.\n"
+        "Setting recalculate_metric=false (the default) uses the metric in the grid "
+        "file.\n"
+        "Setting recalculate_metric=true loads Rxy, Bpxy etc from the grid file.\n"
+        "  This assumes an orthogonal coordinate system. See manual for details.");
   }
 
   if (options["recalculate_metric"]
@@ -227,28 +237,23 @@ int Hermes::init(bool restarting) {
   } else {
     // Check that the grid file contains at least one metric tensor component
     // Note: Older grid files did not, so would silently default to the identity metric
-    if (!(mesh->sourceHasVar("J") or
-          mesh->sourceHasVar("g11") or
-          mesh->sourceHasVar("g22") or
-          mesh->sourceHasVar("g33") or
-          mesh->sourceHasVar("g12") or
-          mesh->sourceHasVar("g23") or
-          mesh->sourceHasVar("g13") or
-          mesh->sourceHasVar("g_11") or
-          mesh->sourceHasVar("g_22") or
-          mesh->sourceHasVar("g_33") or
-          mesh->sourceHasVar("g_12") or
-          mesh->sourceHasVar("g_23") or
-          mesh->sourceHasVar("g_13"))) {
-      throw BoutException("Grid input does not contain any metric components (J, g11, g_22 etc).\n"
-                          "Set hermes:recalculate_metric=true to calculate from Rxy, Bpxy etc.\n"
-                          "If the default identity metric is intended then set e.g. mesh:J=1\n");
+    if (!(mesh->sourceHasVar("J") or mesh->sourceHasVar("g11")
+          or mesh->sourceHasVar("g22") or mesh->sourceHasVar("g33")
+          or mesh->sourceHasVar("g12") or mesh->sourceHasVar("g23")
+          or mesh->sourceHasVar("g13") or mesh->sourceHasVar("g_11")
+          or mesh->sourceHasVar("g_22") or mesh->sourceHasVar("g_33")
+          or mesh->sourceHasVar("g_12") or mesh->sourceHasVar("g_23")
+          or mesh->sourceHasVar("g_13"))) {
+      throw BoutException(
+          "Grid input does not contain any metric components (J, g11, g_22 etc).\n"
+          "Set hermes:recalculate_metric=true to calculate from Rxy, Bpxy etc.\n"
+          "If the default identity metric is intended then set e.g. mesh:J=1\n");
     }
 
     if (options["normalise_metric"]
-             .doc("Normalise input metric tensor? (assumes input is in SI units)")
-             .withDefault<bool>(true)) {
-      Coordinates *coord = mesh->getCoordinates();
+            .doc("Normalise input metric tensor? (assumes input is in SI units)")
+            .withDefault<bool>(true)) {
+      Coordinates* coord = mesh->getCoordinates();
       // To use non-orthogonal metric
       // Normalise
       coord->dx /= rho_s0 * rho_s0 * Bnorm;
@@ -296,7 +301,7 @@ int Hermes::init(bool restarting) {
 int Hermes::rhs(BoutReal time, bool linear) {
   // Need to reset the state, since fields may be modified in transform steps
   state = Options();
-  
+
   set(state["time"], time);
   state["units"] = units.copy();
   set(state["linear"], linear);
@@ -330,82 +335,70 @@ void Hermes::outputVars(Options& options) {
   // Save normalisation quantities. These may be used by components
   // to calculate conversion factors to SI units
 
-  set_with_attrs(options["Tnorm"], Tnorm, {
-      {"units", "eV"},
-      {"conversion", 1}, // Already in SI units
-      {"standard_name", "temperature normalisation"},
-      {"long_name", "temperature normalisation"}
-    });
-  set_with_attrs(options["Nnorm"], Nnorm, {
-      {"units", "m^-3"},
-      {"conversion", 1},
-      {"standard_name", "density normalisation"},
-      {"long_name", "Number density normalisation"}
-    });
-  set_with_attrs(options["Bnorm"], Bnorm, {
-      {"units", "T"},
-      {"conversion", 1},
-      {"standard_name", "magnetic field normalisation"},
-      {"long_name", "Magnetic field normalisation"}
-    });
-  set_with_attrs(options["Cs0"], Cs0, {
-      {"units", "m/s"},
-      {"conversion", 1},
-      {"standard_name", "velocity normalisation"},
-      {"long_name", "Sound speed normalisation"}
-    });
-  set_with_attrs(options["Omega_ci"], Omega_ci, {
-      {"units", "s^-1"},
-      {"conversion", 1},
-      {"standard_name", "frequency normalisation"},
-      {"long_name", "Cyclotron frequency normalisation"}
-    });
-  set_with_attrs(options["rho_s0"], rho_s0, {
-      {"units", "m"},
-      {"conversion", 1},
-      {"standard_name", "length normalisation"},
-      {"long_name", "Gyro-radius length normalisation"}
-    });
+  set_with_attrs(options["Tnorm"], Tnorm,
+                 {{"units", "eV"},
+                  {"conversion", 1}, // Already in SI units
+                  {"standard_name", "temperature normalisation"},
+                  {"long_name", "temperature normalisation"}});
+  set_with_attrs(options["Nnorm"], Nnorm,
+                 {{"units", "m^-3"},
+                  {"conversion", 1},
+                  {"standard_name", "density normalisation"},
+                  {"long_name", "Number density normalisation"}});
+  set_with_attrs(options["Bnorm"], Bnorm,
+                 {{"units", "T"},
+                  {"conversion", 1},
+                  {"standard_name", "magnetic field normalisation"},
+                  {"long_name", "Magnetic field normalisation"}});
+  set_with_attrs(options["Cs0"], Cs0,
+                 {{"units", "m/s"},
+                  {"conversion", 1},
+                  {"standard_name", "velocity normalisation"},
+                  {"long_name", "Sound speed normalisation"}});
+  set_with_attrs(options["Omega_ci"], Omega_ci,
+                 {{"units", "s^-1"},
+                  {"conversion", 1},
+                  {"standard_name", "frequency normalisation"},
+                  {"long_name", "Cyclotron frequency normalisation"}});
+  set_with_attrs(options["rho_s0"], rho_s0,
+                 {{"units", "m"},
+                  {"conversion", 1},
+                  {"standard_name", "length normalisation"},
+                  {"long_name", "Gyro-radius length normalisation"}});
   scheduler->outputVars(options);
 }
 
 void Hermes::restartVars(Options& options) {
-  set_with_attrs(options["Tnorm"], Tnorm, {
-      {"units", "eV"},
-      {"conversion", 1}, // Already in SI units
-      {"standard_name", "temperature normalisation"},
-      {"long_name", "temperature normalisation"}
-    });
-  set_with_attrs(options["Nnorm"], Nnorm, {
-      {"units", "m^-3"},
-      {"conversion", 1},
-      {"standard_name", "density normalisation"},
-      {"long_name", "Number density normalisation"}
-    });
-  set_with_attrs(options["Bnorm"], Bnorm, {
-      {"units", "T"},
-      {"conversion", 1},
-      {"standard_name", "magnetic field normalisation"},
-      {"long_name", "Magnetic field normalisation"}
-    });
-  set_with_attrs(options["Cs0"], Cs0, {
-      {"units", "m/s"},
-      {"conversion", 1},
-      {"standard_name", "velocity normalisation"},
-      {"long_name", "Sound speed normalisation"}
-    });
-  set_with_attrs(options["Omega_ci"], Omega_ci, {
-      {"units", "s^-1"},
-      {"conversion", 1},
-      {"standard_name", "frequency normalisation"},
-      {"long_name", "Cyclotron frequency normalisation"}
-    });
-  set_with_attrs(options["rho_s0"], rho_s0, {
-      {"units", "m"},
-      {"conversion", 1},
-      {"standard_name", "length normalisation"},
-      {"long_name", "Gyro-radius length normalisation"}
-    });
+  set_with_attrs(options["Tnorm"], Tnorm,
+                 {{"units", "eV"},
+                  {"conversion", 1}, // Already in SI units
+                  {"standard_name", "temperature normalisation"},
+                  {"long_name", "temperature normalisation"}});
+  set_with_attrs(options["Nnorm"], Nnorm,
+                 {{"units", "m^-3"},
+                  {"conversion", 1},
+                  {"standard_name", "density normalisation"},
+                  {"long_name", "Number density normalisation"}});
+  set_with_attrs(options["Bnorm"], Bnorm,
+                 {{"units", "T"},
+                  {"conversion", 1},
+                  {"standard_name", "magnetic field normalisation"},
+                  {"long_name", "Magnetic field normalisation"}});
+  set_with_attrs(options["Cs0"], Cs0,
+                 {{"units", "m/s"},
+                  {"conversion", 1},
+                  {"standard_name", "velocity normalisation"},
+                  {"long_name", "Sound speed normalisation"}});
+  set_with_attrs(options["Omega_ci"], Omega_ci,
+                 {{"units", "s^-1"},
+                  {"conversion", 1},
+                  {"standard_name", "frequency normalisation"},
+                  {"long_name", "Cyclotron frequency normalisation"}});
+  set_with_attrs(options["rho_s0"], rho_s0,
+                 {{"units", "m"},
+                  {"conversion", 1},
+                  {"standard_name", "length normalisation"},
+                  {"long_name", "Gyro-radius length normalisation"}});
   scheduler->restartVars(options);
 }
 

--- a/include/div_ops.hxx
+++ b/include/div_ops.hxx
@@ -63,7 +63,7 @@ const Field2D Laplace_FV(const Field2D& k, const Field2D& f);
 /// Perpendicular diffusion including X and Y directions
 /// Takes Div_a_Grad_perp from BOUT++ and adds flows
 const Field3D Div_a_Grad_perp_flows(const Field3D& a, const Field3D& f,
-                                           Field3D& flux_xlow, Field3D& flux_ylow);
+                                    Field3D& flux_xlow, Field3D& flux_ylow);
 /// Same but with upwinding
 /// WARNING: Causes checkerboarding in neutral_mixed integrated test
 const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f);
@@ -73,8 +73,8 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
                                            Field3D& flux_xlow, Field3D& flux_ylow);
 
 /// Version with energy flow diagnostic
-const Field3D Div_par_K_Grad_par_mod(const Field3D& k, const Field3D& f, Field3D& flow_ylow,
-                                     bool bndry_flux = true);
+Field3D Div_par_K_Grad_par_mod(const Field3D& k, const Field3D& f, Field3D& flow_ylow,
+                               bool bndry_flux = true);
 
 /*!
  * Div ( a Grad_perp(f) ) -- ∇⊥ ( a ⋅ ∇⊥ f) -- Vorticity
@@ -237,8 +237,8 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
           } else {
             // Add flux due to difference in boundary values
             flux = s.R * sv.R * sv.R // Use right cell edge values
-              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
-              * n_mid * (sv.R - v_mid); // Damp differences in velocity, not flux
+                   + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p)) * n_mid
+                         * (sv.R - v_mid); // Damp differences in velocity, not flux
           }
         } else {
           // Maximum wave speed in the two cells
@@ -264,10 +264,9 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
             flux = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux =
-              s.L * sv.L * sv.L
-              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
-              * n_mid * (sv.L - v_mid);
+            flux = s.L * sv.L * sv.L
+                   - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m)) * n_mid
+                         * (sv.L - v_mid);
           }
         } else {
           // Maximum wave speed in the two cells
@@ -289,7 +288,7 @@ const Field3D Div_par_fvv(const Field3D& f_in, const Field3D& v_in,
 // and flow of kinetic energy (in flow_ylow)
 template <typename CellEdges = MC>
 const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
-                                  const Field3D& wave_speed_in, Field3D &flow_ylow,
+                                  const Field3D& wave_speed_in, Field3D& flow_ylow,
                                   bool fixflux = true) {
 
   ASSERT1(areFieldsCompatible(f_in, v_in));
@@ -397,8 +396,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
             flux_mom = n_mid * v_mid * v_mid;
           } else {
             flux_mom = s.R * sv.R * sv.R
-              + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
-              * (s.R * sv.R - n_mid * v_mid);
+                       + BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.p))
+                             * (s.R * sv.R - n_mid * v_mid);
           }
 
           // Assume that particle flux is fixed to boundary value
@@ -406,7 +405,7 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
           BoutReal actual_ke = sv.c * flux_mom - 0.5 * sv.c * sv.c * flux_part;
-          
+
           // Note: If the actual loss was higher than expected, then
           //       plasma heating is needed to compensate
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_rc;
@@ -420,7 +419,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
                                   fabs(sv.c), fabs(sv.p));
 
           // Viscous heating due to relaxation of velocity towards midpoint
-          result(i, j, k) += (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
+          result(i, j, k) +=
+              (amax + 0.5 * sv.R) * s.R * (sv.c - sv.p) * (sv.R - v_mid) * flux_factor_rc;
 
           // Kinetic energy flow into next cell.
           // Note: Different from flow out of this cell; the difference
@@ -428,7 +428,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
           BoutReal flux_part = s.R * 0.5 * (sv.R + amax);
           BoutReal flux_mom = flux_part * sv.R;
 
-          flow_ylow(i, j + 1, k) += (sv.p * flux_mom - 0.5 * SQ(sv.p) * flux_part) * area_rp;
+          flow_ylow(i, j + 1, k) +=
+              (sv.p * flux_mom - 0.5 * SQ(sv.p) * flux_part) * area_rp;
         }
 
         ////////////////////////////////////////////
@@ -438,8 +439,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
         n_mid = 0.5 * (s.c + s.m);
 
         // Expected KE loss. Note minus sign because negative v into boundary
-        BoutReal expected_ke = - 0.5 * n_mid * v_mid * v_mid * v_mid;
-        
+        BoutReal expected_ke = -0.5 * n_mid * v_mid * v_mid * v_mid;
+
         if (mesh->firstY(i) && (j == mesh->ystart) && !mesh->periodicY(i)) {
           // First point in domain
           BoutReal flux_mom;
@@ -448,17 +449,16 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
             flux_mom = n_mid * v_mid * v_mid;
           } else {
             // Add flux due to difference in boundary values
-            flux_mom =
-              s.L * sv.L * sv.L
-              - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
-              * (s.L * sv.L - n_mid * v_mid);
+            flux_mom = s.L * sv.L * sv.L
+                       - BOUTMAX(wave_speed(i, j, k), fabs(sv.c), fabs(sv.m))
+                             * (s.L * sv.L - n_mid * v_mid);
           }
 
           // Assume that density flux is fixed to boundary value
           const BoutReal flux_part = n_mid * v_mid;
 
           // d/dt(1/2 m n v^2) = v * d/dt(mnv) - 1/2 m v^2 * dn/dt
-          BoutReal actual_ke = - sv.c * flux_mom + 0.5 * sv.c * sv.c * flux_part;
+          BoutReal actual_ke = -sv.c * flux_mom + 0.5 * sv.c * sv.c * flux_part;
 
           result(i, j, k) += (actual_ke - expected_ke) * flux_factor_lc;
 
@@ -469,7 +469,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
                                   fabs(sv.c), fabs(sv.m));
 
           // Viscous heating due to relaxation
-          result(i, j, k) += (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
+          result(i, j, k) +=
+              (amax - 0.5 * sv.L) * s.L * (sv.c - sv.m) * (sv.L - v_mid) * flux_factor_lc;
 
           // Kinetic energy flow into this cell.
           // Note: Different from flow out of left cell; the difference
@@ -485,7 +486,7 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
   flow_ylow = fromFieldAligned(flow_ylow, "RGN_NOBNDRY");
   return fromFieldAligned(result, "RGN_NOBNDRY");
 }
-  
+
 /// Finite volume parallel divergence
 ///
 /// NOTE: Modified version, applies limiter to velocity and field
@@ -510,8 +511,8 @@ const Field3D Div_par_fvv_heating(const Field3D& f_in, const Field3D& v_in,
 /// NB: Uses to/from FieldAligned coordinates
 template <typename CellEdges = MC>
 const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
-                          const Field3D& wave_speed_in,
-                          Field3D &flow_ylow, bool fixflux = true) {
+                          const Field3D& wave_speed_in, Field3D& flow_ylow,
+                          bool fixflux = true) {
 
   ASSERT1_FIELDS_COMPATIBLE(f_in, v_in);
   ASSERT1_FIELDS_COMPATIBLE(f_in, wave_speed_in);
@@ -573,7 +574,7 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
           common_factor / (coord->dy(i, j + 1) * coord->J(i, j + 1));
 
       BoutReal area_rp = common_factor * coord->dx(i, j + 1) * coord->dz(i, j + 1);
-      
+
       // For left cell boundaries
       common_factor = (coord->J(i, j) + coord->J(i, j - 1))
                       / (sqrt(coord->g_22(i, j)) + sqrt(coord->g_22(i, j - 1)));
@@ -590,13 +591,14 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
         BoutReal common_factor =
             (coord->J(i, j, k) + coord->J(i, j + 1, k))
             / (sqrt(coord->g_22(i, j, k)) + sqrt(coord->g_22(i, j + 1, k)));
-        
+
         BoutReal flux_factor_rc =
             common_factor / (coord->dy(i, j, k) * coord->J(i, j, k));
         BoutReal flux_factor_rp =
             common_factor / (coord->dy(i, j + 1, k) * coord->J(i, j + 1, k));
 
-        BoutReal area_rp = common_factor * coord->dx(i, j + 1, k) * coord->dz(i, j + 1, k);
+        BoutReal area_rp =
+            common_factor * coord->dx(i, j + 1, k) * coord->dz(i, j + 1, k);
 
         // For left cell boundaries
         common_factor = (coord->J(i, j, k) + coord->J(i, j - 1, k))
@@ -708,7 +710,8 @@ const Field3D Div_par_mod(const Field3D& f_in, const Field3D& v_in,
 ///
 /// 1st order upwinding is used in Y.
 template <typename CellEdges = MC>
-const Field3D Div_a_Grad_perp_limit(const Field3D& a, const Field3D& g, const Field3D& f) {
+const Field3D Div_a_Grad_perp_limit(const Field3D& a, const Field3D& g,
+                                    const Field3D& f) {
   ASSERT2(a.getLocation() == f.getLocation());
 
   Mesh* mesh = a.getMesh();
@@ -735,8 +738,8 @@ const Field3D Div_a_Grad_perp_limit(const Field3D& a, const Field3D& g, const Fi
         // Mid-point average boundary value of 'a'
         const BoutReal aedge = 0.5 * (a(i + 1, j, k) + a(i, j, k));
         BoutReal gedge;
-        if (((i == mesh->xstart - 1) and mesh->firstX()) or
-            ((i == mesh->xend) and mesh->lastX())) {
+        if (((i == mesh->xstart - 1) and mesh->firstX())
+            or ((i == mesh->xend) and mesh->lastX())) {
           // Mid-point average boundary value of 'g'
           gedge = 0.5 * (g(i + 1, j, k) + g(i, j, k));
         } else if (gradient > 0) {
@@ -774,7 +777,7 @@ const Field3D Div_a_Grad_perp_limit(const Field3D& a, const Field3D& g, const Fi
       }
     }
   }
-  
+
   // Y and Z fluxes require Y derivatives
 
   // Fields containing values along the magnetic field
@@ -912,8 +915,8 @@ const Field3D Div_a_Grad_perp_limit(const Field3D& a, const Field3D& g, const Fi
                   * (fup(i, j + 1, k) + fup(i, j + 1, kp) - fdown(i, j - 1, k)
                      - fdown(i, j - 1, kp));
 
-        BoutReal fout = gradient * 0.5*(ac(i,j,kp) + ac(i,j,k)) *
-          ((gradient > 0) ? gc(i, j, kp) : gc(i, j, k));
+        BoutReal fout = gradient * 0.5 * (ac(i, j, kp) + ac(i, j, k))
+                        * ((gradient > 0) ? gc(i, j, kp) : gc(i, j, k));
 
         yzresult(i, j, k) += fout / coord->dz(i, j);
         yzresult(i, j, kp) -= fout / coord->dz(i, j);

--- a/include/hermes_build_config.hxx.in
+++ b/include/hermes_build_config.hxx.in
@@ -4,6 +4,8 @@
 
 #include <bout/fv_ops.hxx>
 
+#include "div_ops.hxx" // For Superbee
+
 namespace hermes {
   /// Slope limiter to use in advection operators
   using Limiter=FV::@HERMES_SLOPE_LIMITER@;

--- a/include/hermes_build_config.hxx.in
+++ b/include/hermes_build_config.hxx.in
@@ -4,12 +4,16 @@
 
 #include <bout/fv_ops.hxx>
 
-#include "div_ops.hxx" // For Superbee
-
 namespace hermes {
   /// Slope limiter to use in advection operators
   using Limiter=FV::@HERMES_SLOPE_LIMITER@;
   const char* const limiter_typename = "@HERMES_SLOPE_LIMITER@";
+
+  // Method used in Div_par_K_Grad_par_mod
+  enum class ConductionMethod {Original, ProductJK, Harmonic};
+
+  constexpr ConductionMethod conduction_method = ConductionMethod::@HERMES_CONDUCTION_METHOD@;
+  const char* const conduction_typename = "@HERMES_CONDUCTION_METHOD@";
 }
 
 #endif // HERMES_BUILD_CONFIG_HXX

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -159,7 +159,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
       } else if (conduction_collisions_mode == "multispecies") {
         for (const auto& collision : species["collision_frequencies"].getChildren()) {
 
-          std::string const collision_name = collision.second.name();
+          const std::string collision_name = collision.second.name();
 
           if ( /// Charge exchange
               (collisionSpeciesMatch(collision_name, species.name(), "", "cx", "partial"))
@@ -174,7 +174,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
       } else if (conduction_collisions_mode == "afn") {
         for (const auto& collision : species["collision_frequencies"].getChildren()) {
 
-          std::string const collision_name = collision.second.name();
+          const std::string collision_name = collision.second.name();
 
           if (species_type != SpeciesType::neutral) {
             throw BoutException("\tAFN conduction collisions mode not available for ions "
@@ -233,10 +233,9 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
 
     Field3D P = GET_VALUE(Field3D, species["pressure"]);
     P.clearParallelSlices();
-    P.setBoundaryTo(get<Field3D>(species["pressure"]));
-    Field3D const Pfloor = floor(P, 0.0); // Restricted to never go below zero
-    Field3D const T = get<Field3D>(species["temperature"]);
-    Field3D const N = get<Field3D>(species["density"]);
+    const Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
+    const Field3D T = get<Field3D>(species["temperature"]);
+    const Field3D N = get<Field3D>(species["density"]);
 
     // Calculate ion collision times
     const Field3D tau = 1. / softFloor(nu, 1e-10);
@@ -262,9 +261,9 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
        */
 
       // Spitzer-Harm heat flux
-      Field3D const q_SH = kappa_par * Grad_par(T);
+      const Field3D q_SH = kappa_par * Grad_par(T);
       // Free-streaming flux
-      Field3D const q_fl = kappa_limit_alpha * N * T * sqrt(T / AA);
+      const Field3D q_fl = kappa_limit_alpha * N * T * sqrt(T / AA);
 
       // This results in a harmonic average of the heat fluxes
       kappa_par /= (1. + abs(q_SH / softFloor(q_fl, 1e-10)));
@@ -321,7 +320,7 @@ void BraginskiiConduction::outputVars(Options& state) {
   auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
   auto rho_s0 = get<BoutReal>(state["rho_s0"]);
 
-  BoutReal const Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
+  const BoutReal Pnorm = SI::qe * Tnorm * Nnorm; // Pressure normalisation
 
   for (const auto& [name, diagnose] : all_diagnose) {
     if (!diagnose) {

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -1,6 +1,6 @@
 /*
-    Copyright B.Dudson, J.Leddy, University of York, September 2016
-              email: benjamin.dudson@york.ac.uk
+    Copyright 2016 - 2026 BOUT++ contributors
+              email: dudson2@llnl.gov
 
     This file is part of Hermes.
 
@@ -22,13 +22,19 @@
 #include <mpi.h>
 
 #include "../include/div_ops.hxx"
+#include "../include/hermes_build_config.hxx"
 
 #include <bout/assert.hxx>
+#include <bout/bout_types.hxx>
+#include <bout/coordinates.hxx>
 #include <bout/derivs.hxx>
+#include <bout/field.hxx>
+#include <bout/field3d.hxx>
 #include <bout/fv_ops.hxx>
 #include <bout/globals.hxx>
 #include <bout/mesh.hxx>
 #include <bout/output.hxx>
+#include <bout/region.hxx>
 #include <bout/utils.hxx>
 
 #include <algorithm>
@@ -1688,7 +1694,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
           // Not at a boundary
           if (vR > 0.0) {
             // Flux out into next cell
-            BoutReal flux = vR * s.R * gR;
+            const BoutReal flux = vR * s.R * gR;
             result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
             result(i + 1, j, k) -= flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
           }
@@ -1717,7 +1723,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
           // Not at a boundary
 
           if (vL < 0.0) {
-            BoutReal flux = vL * s.L * gL;
+            const BoutReal flux = vL * s.L * gL;
             result(i, j, k) -= flux / (coord->dx(i, j) * coord->J(i, j));
             result(i - 1, j, k) += flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
           }
@@ -1734,12 +1740,12 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
         MC(s);
 
         if (vU > 0.0) {
-          BoutReal flux = vU * s.R * gU / (coord->J(i, j) * coord->dz(i, j));
+          const BoutReal flux = vU * s.R * gU / (coord->J(i, j) * coord->dz(i, j));
           result(i, j, k) += flux;
           result(i, j, kp) -= flux;
         }
         if (vD < 0.0) {
-          BoutReal flux = vD * s.L * gD / (coord->J(i, j) * coord->dz(i, j));
+          const BoutReal flux = vD * s.L * gD / (coord->J(i, j) * coord->dz(i, j));
           result(i, j, k) -= flux;
           result(i, j, km) += flux;
         }
@@ -1750,8 +1756,6 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
   return result;
 }
 
-constexpr int CONDUCTION_METHOD = 0;
-
 Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& flow_ylow,
                                bool bndry_flux) {
   TRACE("FV::Div_par_K_Grad_par_mod");
@@ -1760,7 +1764,7 @@ Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& 
 
   Mesh* mesh = Kin.getMesh();
 
-  bool use_parallel_slices = (Kin.hasParallelSlices() && fin.hasParallelSlices());
+  const bool use_parallel_slices = (Kin.hasParallelSlices() && fin.hasParallelSlices());
 
   const auto& K = use_parallel_slices ? Kin : toFieldAligned(Kin, "RGN_NOX");
   const auto& f = use_parallel_slices ? fin : toFieldAligned(fin, "RGN_NOX");
@@ -1784,30 +1788,30 @@ Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& 
 
     if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x())
         || (i.y() != mesh->yend)) {
+      BoutReal flux = 0.0;
 
-      if constexpr (CONDUCTION_METHOD == 0) {
-        BoutReal c = 0.5 * (K[i] + Kup[iyp]);             // K at the upper boundary
-        BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
-        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
+      if constexpr (hermes::conduction_method == hermes::ConductionMethod::Original) {
+        const BoutReal c = 0.5 * (K[i] + Kup[iyp]);             // K at the upper boundary
+        const BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
+        const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
 
-        BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
+        const BoutReal gradient =
+            2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
 
-        BoutReal flux = c * J * gradient / g_22;
-
-        result[i] += flux / (coord->dy[i] * coord->J[i]);
-
-      } else if constexpr (CONDUCTION_METHOD == 1) {
+        flux = c * J * gradient / g_22;
+      } else if constexpr (hermes::conduction_method
+                           == hermes::ConductionMethod::ProductJK) {
         // Intended to reduce sensitivity of result to K in small cells
-        BoutReal cJ =
+        const BoutReal cJ =
             0.5 * (K[i] * coord->J[i] + Kup[iyp] * coord->J[iyp]); // K * J at boundary
-        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
+        const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
 
-        BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
+        const BoutReal gradient =
+            2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
 
-        BoutReal flux = cJ * gradient / g_22;
-
-        result[i] += flux / (coord->dy[i] * coord->J[i]);
-      } else if constexpr (CONDUCTION_METHOD == 2) {
+        flux = cJ * gradient / g_22;
+      } else if constexpr (hermes::conduction_method
+                           == hermes::ConductionMethod::Harmonic) {
         // Harmonic average (serial resistance)
         const BoutReal cond_i = K[i] * coord->J[i] / (coord->g_22[i] * coord->dy[i]);
         const BoutReal cond_iyp =
@@ -1820,10 +1824,9 @@ Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& 
                 ? 2.0 * cond_i * cond_iyp / denom
                 : 0.0;
 
-        const BoutReal flux = C_edge * (fup[iyp] - f[i]);
-
-        result[i] += flux / (coord->dy[i] * coord->J[i]);
+        flux = C_edge * (fup[iyp] - f[i]);
       }
+      result[i] += flux / (coord->dy[i] * coord->J[i]);
     }
 
     // Calculate flux at lower surface
@@ -1831,23 +1834,27 @@ Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& 
         || (i.y() != mesh->ystart)) {
       BoutReal flux = 0.0;
 
-      if constexpr (CONDUCTION_METHOD == 0) {
-        BoutReal c = 0.5 * (K[i] + Kdown[iym]);           // K at the lower boundary
-        BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
-        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
+      if constexpr (hermes::conduction_method == hermes::ConductionMethod::Original) {
+        const BoutReal c = 0.5 * (K[i] + Kdown[iym]);           // K at the lower boundary
+        const BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
+        const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
 
-        BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
+        const BoutReal gradient =
+            2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
 
         flux = c * J * gradient / g_22;
-      } else if constexpr (CONDUCTION_METHOD == 1) {
-        BoutReal cJ =
+      } else if constexpr (hermes::conduction_method
+                           == hermes::ConductionMethod::ProductJK) {
+        const BoutReal cJ =
             0.5 * (K[i] * coord->J[i] + Kdown[iym] * coord->J[iym]); // K * J at boundary
-        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
+        const BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
 
-        BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
+        const BoutReal gradient =
+            2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
 
         flux = cJ * gradient / g_22;
-      } else if constexpr (CONDUCTION_METHOD == 2) {
+      } else if constexpr (hermes::conduction_method
+                           == hermes::ConductionMethod::Harmonic) {
         const BoutReal cond_i = K[i] * coord->J[i] / (coord->g_22[i] * coord->dy[i]);
         const BoutReal cond_iym =
             Kdown[iym] * coord->J[iym] / (coord->g_22[iym] * coord->dy[iym]);

--- a/src/div_ops.cxx
+++ b/src/div_ops.cxx
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 using bout::globals::mesh;
 
@@ -42,17 +43,19 @@ const Field3D Div_par_diffusion_index(const Field3D& f, bool bndry_flux) {
 
   Coordinates* coord = mesh->getCoordinates();
 
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
-    for (int j = mesh->ystart - 1; j <= mesh->yend; j++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart - 1; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         // Calculate flux at upper surface
 
         if (!bndry_flux && !mesh->periodicY(i)) {
-          if ((j == mesh->yend) && mesh->lastY(i))
+          if ((j == mesh->yend) && mesh->lastY(i)) {
             continue;
+          }
 
-          if ((j == mesh->ystart - 1) && mesh->firstY(i))
+          if ((j == mesh->ystart - 1) && mesh->firstY(i)) {
             continue;
+          }
         }
         BoutReal J = 0.5 * (coord->J(i, j) + coord->J(i, j + 1)); // Jacobian at boundary
 
@@ -63,6 +66,8 @@ const Field3D Div_par_diffusion_index(const Field3D& f, bool bndry_flux) {
         result(i, j, k) += flux / coord->J(i, j);
         result(i, j + 1, k) -= flux / coord->J(i, j + 1);
       }
+    }
+  }
   return result;
 }
 
@@ -91,8 +96,7 @@ BoutReal minmod(BoutReal a, BoutReal b, BoutReal c) {
 
 // Monotonized Central limiter (Van-Leer)
 void MC(Stencil1D& n) {
-  BoutReal slope =
-      minmod(2. * (n.p - n.c), 0.5 * (n.p - n.m), 2. * (n.c - n.m));
+  BoutReal slope = minmod(2. * (n.p - n.c), 0.5 * (n.p - n.m), 2. * (n.c - n.m));
   n.L = n.c - 0.5 * slope;
   n.R = n.c + 0.5 * slope;
 }
@@ -126,8 +130,8 @@ const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f, bool bnd
   //
 
   int nz = mesh->LocalNz;
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
-    for (int j = mesh->ystart; j <= mesh->yend; j++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < nz; k++) {
         int kp = (k + 1) % nz;
         int kpp = (kp + 1) % nz;
@@ -249,6 +253,8 @@ const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f, bool bnd
           result(i, j, km) += flux;
         }
       }
+    }
+  }
   FV::communicateFluxes(result);
 
   //////////////////////////////////////////
@@ -288,8 +294,8 @@ const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f, bool bnd
       }
     }
 
-    for (int i = xs; i <= xe; i++)
-      for (int j = mesh->ystart - 1; j <= mesh->yend; j++)
+    for (int i = xs; i <= xe; i++) {
+      for (int j = mesh->ystart - 1; j <= mesh->yend; j++) {
         for (int k = 0; k < mesh->LocalNz; k++) {
 
           // Average dfdy to right X boundary
@@ -325,6 +331,8 @@ const Field3D Div_n_bxGrad_f_B_XPPM(const Field3D& n, const Field3D& f, bool bnd
           result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
           result(i + 1, j, k) -= flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
         }
+      }
+    }
   }
 
   if (poloidal) {
@@ -431,8 +439,8 @@ const Field3D Div_Perp_Lap_FV_Index(const Field3D& as, const Field3D& fs) {
 
   Coordinates* coord = mesh->getCoordinates();
 
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
-    for (int j = mesh->ystart; j <= mesh->yend; j++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         int kp = (k + 1) % mesh->LocalNz;
         int km = (k - 1 + mesh->LocalNz) % mesh->LocalNz;
@@ -469,17 +477,19 @@ const Field3D Div_Perp_Lap_FV_Index(const Field3D& as, const Field3D& fs) {
         flux = gD * 0.5 * (as(i, j, k) + as(i, j, km));
         result(i, j, k) -= flux;
       }
+    }
+  }
 
   return result;
 }
 
 /// Z diffusion in index space
-const Field3D Div_Z_FV_Index(const Field3D &as, const Field3D &fs) {
+const Field3D Div_Z_FV_Index(const Field3D& as, const Field3D& fs) {
 
   Field3D result = 0.0;
 
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
-    for (int j = mesh->ystart; j <= mesh->yend; j++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
+    for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         int kp = (k + 1) % mesh->LocalNz;
         int km = (k - 1 + mesh->LocalNz) % mesh->LocalNz;
@@ -494,7 +504,9 @@ const Field3D Div_Z_FV_Index(const Field3D &as, const Field3D &fs) {
 
         result(i, j, k) -= gD * 0.5 * (as(i, j, k) + as(i, j, km));
       }
-  
+    }
+  }
+
   return result;
 }
 
@@ -504,7 +516,7 @@ const Field3D D4DX4_FV_Index(const Field3D& f, bool bndry_flux) {
 
   Coordinates* coord = mesh->getCoordinates();
 
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
 
@@ -576,6 +588,7 @@ const Field3D D4DX4_FV_Index(const Field3D& f, bool bndry_flux) {
         }
       }
     }
+  }
 
   return result;
 }
@@ -584,7 +597,7 @@ const Field3D D4DZ4_Index(const Field3D& f) {
   Field3D result;
   result.allocate();
   BOUT_FOR(i, f.getRegion("RGN_NOBNDRY")) {
-    result[i] = f[i.zp(2)] - 4.*f[i.zp()] + 6 * f[i] - 4 * f[i.zm()] + f[i.zm(2)];
+    result[i] = f[i.zp(2)] - 4. * f[i.zp()] + 6 * f[i] - 4 * f[i.zm()] + f[i.zm(2)];
   }
   return result;
 }
@@ -602,7 +615,7 @@ const Field2D Laplace_FV(const Field2D& k, const Field2D& f) {
 
   Coordinates* coord = mesh->getCoordinates();
 
-  for (int i = mesh->xstart; i <= mesh->xend; i++)
+  for (int i = mesh->xstart; i <= mesh->xend; i++) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
 
       // Calculate gradients on cell faces
@@ -641,12 +654,12 @@ const Field2D Laplace_FV(const Field2D& k, const Field2D& f) {
       flux = gD * 0.25 * (coord->J(i, j - 1) + coord->J(i, j)) * (k(i, j - 1) + k(i, j));
       result(i, j) -= flux / (coord->dy(i, j) * coord->J(i, j));
     }
+  }
   return result;
 }
 
 const Field3D Div_a_Grad_perp_flows(const Field3D& a, const Field3D& f,
-                              Field3D &flow_xlow, 
-                              Field3D &flow_ylow) {
+                                    Field3D& flow_xlow, Field3D& flow_ylow) {
   ASSERT2(a.getLocation() == f.getLocation());
 
   Mesh* mesh = a.getMesh();
@@ -890,7 +903,7 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
   int xs = mesh->xstart - 1;
   int xe = mesh->xend;
 
-  for (int i = xs; i <= xe; i++)
+  for (int i = xs; i <= xe; i++) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         // Calculate flux from i to i+1
@@ -907,6 +920,7 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
         result(i + 1, j, k) -= fout / (coord->dx(i + 1, j) * coord->J(i + 1, j));
       }
     }
+  }
 
   // Y and Z fluxes require Y derivatives
 
@@ -970,9 +984,9 @@ const Field3D Div_a_Grad_perp_upwind(const Field3D& a, const Field3D& f) {
                         / (coord->dy(i, j + 1) + coord->dy(i, j));
 
         BoutReal fout = 0.25 * (ac(i, j, k) + aup(i, j + 1, k))
-                            * (coord->J(i, j) * coord->g23(i, j)
-                               + coord->J(i, j + 1) * coord->g23(i, j + 1))
-                            * (dfdz - coef_u * dfdy);
+                        * (coord->J(i, j) * coord->g23(i, j)
+                           + coord->J(i, j + 1) * coord->g23(i, j + 1))
+                        * (dfdz - coef_u * dfdy);
 
         yzresult(i, j, k) = fout / (coord->dy(i, j) * coord->J(i, j));
 
@@ -1398,7 +1412,7 @@ Field3D Div_a_Grad_perp_nonorthog(const Field3D& a, const Field3D& f, Field3D& f
 /// Flows are always in the positive {x,y} direction
 /// i.e xlow(i,j) is the flow into cell (i,j) from the left,
 ///               and the flow out of cell (i-1,j) to the right
-/// 
+///
 ///           ylow(i,j+1)
 ///              ^
 ///           +---|---+
@@ -1411,8 +1425,7 @@ Field3D Div_a_Grad_perp_nonorthog(const Field3D& a, const Field3D& f, Field3D& f
 ///
 /// WARNING: Causes checkerboarding in neutral_mixed integrated test
 const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
-                                           Field3D &flow_xlow,
-                                           Field3D &flow_ylow) {
+                                           Field3D& flow_xlow, Field3D& flow_ylow) {
   ASSERT2(a.getLocation() == f.getLocation());
 
   Mesh* mesh = a.getMesh();
@@ -1430,13 +1443,13 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
   int xs = mesh->xstart - 1;
   int xe = mesh->xend;
 
-  for (int i = xs; i <= xe; i++)
+  for (int i = xs; i <= xe; i++) {
     for (int j = mesh->ystart; j <= mesh->yend; j++) {
       for (int k = 0; k < mesh->LocalNz; k++) {
         // Calculate flux from i to i+1
 
         const BoutReal gradient = (coord->J(i, j) * coord->g11(i, j)
-                                     + coord->J(i + 1, j) * coord->g11(i + 1, j))
+                                   + coord->J(i + 1, j) * coord->g11(i + 1, j))
                                   * (f(i + 1, j, k) - f(i, j, k))
                                   / (coord->dx(i, j) + coord->dx(i + 1, j));
 
@@ -1450,6 +1463,7 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
         flow_xlow(i + 1, j, k) = -1.0 * fout * coord->dy(i, j) * coord->dz(i, j);
       }
     }
+  }
 
   // Y and Z fluxes require Y derivatives
 
@@ -1514,9 +1528,9 @@ const Field3D Div_a_Grad_perp_upwind_flows(const Field3D& a, const Field3D& f,
                         / (coord->dy(i, j + 1) + coord->dy(i, j));
 
         BoutReal fout = 0.25 * (ac(i, j, k) + aup(i, j + 1, k))
-                            * (coord->J(i, j) * coord->g23(i, j)
-                               + coord->J(i, j + 1) * coord->g23(i, j + 1))
-                            * (dfdz - coef_u * dfdy);
+                        * (coord->J(i, j) * coord->g23(i, j)
+                           + coord->J(i, j + 1) * coord->g23(i, j + 1))
+                        * (dfdz - coef_u * dfdy);
 
         yzresult(i, j, k) = fout / (coord->dy(i, j) * coord->J(i, j));
 
@@ -1585,8 +1599,8 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
                                     bool bndry_flux) {
   Field3D result{0.0};
 
-  Coordinates *coord = mesh->getCoordinates();
-  
+  Coordinates* coord = mesh->getCoordinates();
+
   //////////////////////////////////////////
   // X-Z advection.
   //
@@ -1613,24 +1627,25 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
 
         // 1) Interpolate stream function f onto corners fmp, fpp, fpm
 
-        BoutReal fmm = 0.25 * (f(i, j, k) + f(i - 1, j, k) + f(i, j, km) +
-                               f(i - 1, j, km));
-        BoutReal fmp = 0.25 * (f(i, j, k) + f(i, j, kp) + f(i - 1, j, k) +
-                               f(i - 1, j, kp)); // 2nd order accurate
-        BoutReal fpp = 0.25 * (f(i, j, k) + f(i, j, kp) + f(i + 1, j, k) +
-                               f(i + 1, j, kp));
-        BoutReal fpm = 0.25 * (f(i, j, k) + f(i + 1, j, k) + f(i, j, km) +
-                               f(i + 1, j, km));
+        BoutReal fmm =
+            0.25 * (f(i, j, k) + f(i - 1, j, k) + f(i, j, km) + f(i - 1, j, km));
+        BoutReal fmp = 0.25
+                       * (f(i, j, k) + f(i, j, kp) + f(i - 1, j, k)
+                          + f(i - 1, j, kp)); // 2nd order accurate
+        BoutReal fpp =
+            0.25 * (f(i, j, k) + f(i, j, kp) + f(i + 1, j, k) + f(i + 1, j, kp));
+        BoutReal fpm =
+            0.25 * (f(i, j, k) + f(i + 1, j, k) + f(i, j, km) + f(i + 1, j, km));
 
         // 2) Calculate velocities on cell faces
 
         BoutReal vU = coord->J(i, j) * (fmp - fpp) / coord->dx(i, j); // -J*df/dx
         BoutReal vD = coord->J(i, j) * (fmm - fpm) / coord->dx(i, j); // -J*df/dx
 
-        BoutReal vR = 0.5 * (coord->J(i, j) + coord->J(i + 1, j)) * (fpp - fpm) /
-                      coord->dz(i, j); // J*df/dz
-        BoutReal vL = 0.5 * (coord->J(i, j) + coord->J(i - 1, j)) * (fmp - fmm) /
-                      coord->dz(i, j); // J*df/dz
+        BoutReal vR = 0.5 * (coord->J(i, j) + coord->J(i + 1, j)) * (fpp - fpm)
+                      / coord->dz(i, j); // J*df/dz
+        BoutReal vL = 0.5 * (coord->J(i, j) + coord->J(i - 1, j)) * (fmp - fmm)
+                      / coord->dz(i, j); // J*df/dz
 
         // 3) Calculate g on cell faces
 
@@ -1667,8 +1682,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
             }
 
             result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
-            result(i + 1, j, k) -=
-                flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
+            result(i + 1, j, k) -= flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
           }
         } else {
           // Not at a boundary
@@ -1676,8 +1690,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
             // Flux out into next cell
             BoutReal flux = vR * s.R * gR;
             result(i, j, k) += flux / (coord->dx(i, j) * coord->J(i, j));
-            result(i + 1, j, k) -=
-                flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
+            result(i + 1, j, k) -= flux / (coord->dx(i + 1, j) * coord->J(i + 1, j));
           }
         }
 
@@ -1698,8 +1711,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
               flux = vL * 0.5 * (n(i - 1, j, k) + n(i, j, k)) * gL;
             }
             result(i, j, k) -= flux / (coord->dx(i, j) * coord->J(i, j));
-            result(i - 1, j, k) +=
-                flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
+            result(i - 1, j, k) += flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
           }
         } else {
           // Not at a boundary
@@ -1707,8 +1719,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
           if (vL < 0.0) {
             BoutReal flux = vL * s.L * gL;
             result(i, j, k) -= flux / (coord->dx(i, j) * coord->J(i, j));
-            result(i - 1, j, k) +=
-                flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
+            result(i - 1, j, k) += flux / (coord->dx(i - 1, j) * coord->J(i - 1, j));
           }
         }
 
@@ -1723,7 +1734,7 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
         MC(s);
 
         if (vU > 0.0) {
-          BoutReal flux = vU * s.R * gU/ (coord->J(i, j) * coord->dz(i, j));
+          BoutReal flux = vU * s.R * gU / (coord->J(i, j) * coord->dz(i, j));
           result(i, j, k) += flux;
           result(i, j, kp) -= flux;
         }
@@ -1739,9 +1750,10 @@ const Field3D Div_n_g_bxGrad_f_B_XZ(const Field3D& n, const Field3D& g, const Fi
   return result;
 }
 
-const Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin,
-                                     Field3D& flow_ylow,
-                                     bool bndry_flux) {
+constexpr int CONDUCTION_METHOD = 0;
+
+Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin, Field3D& flow_ylow,
+                               bool bndry_flux) {
   TRACE("FV::Div_par_K_Grad_par_mod");
 
   ASSERT2(Kin.getLocation() == fin.getLocation());
@@ -1773,31 +1785,84 @@ const Field3D Div_par_K_Grad_par_mod(const Field3D& Kin, const Field3D& fin,
     if (bndry_flux || mesh->periodicY(i.x()) || !mesh->lastY(i.x())
         || (i.y() != mesh->yend)) {
 
-      BoutReal c = 0.5 * (K[i] + Kup[iyp]);             // K at the upper boundary
-      BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
-      BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
+      if constexpr (CONDUCTION_METHOD == 0) {
+        BoutReal c = 0.5 * (K[i] + Kup[iyp]);             // K at the upper boundary
+        BoutReal J = 0.5 * (coord->J[i] + coord->J[iyp]); // Jacobian at boundary
+        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
 
-      BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
+        BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
 
-      BoutReal flux = c * J * gradient / g_22;
+        BoutReal flux = c * J * gradient / g_22;
 
-      result[i] += flux / (coord->dy[i] * coord->J[i]);
+        result[i] += flux / (coord->dy[i] * coord->J[i]);
+
+      } else if constexpr (CONDUCTION_METHOD == 1) {
+        // Intended to reduce sensitivity of result to K in small cells
+        BoutReal cJ =
+            0.5 * (K[i] * coord->J[i] + Kup[iyp] * coord->J[iyp]); // K * J at boundary
+        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iyp]);
+
+        BoutReal gradient = 2. * (fup[iyp] - f[i]) / (coord->dy[i] + coord->dy[iyp]);
+
+        BoutReal flux = cJ * gradient / g_22;
+
+        result[i] += flux / (coord->dy[i] * coord->J[i]);
+      } else if constexpr (CONDUCTION_METHOD == 2) {
+        // Harmonic average (serial resistance)
+        const BoutReal cond_i = K[i] * coord->J[i] / (coord->g_22[i] * coord->dy[i]);
+        const BoutReal cond_iyp =
+            Kup[iyp] * coord->J[iyp] / (coord->g_22[iyp] * coord->dy[iyp]);
+        const BoutReal denom = cond_i + cond_iyp;
+
+        // Harmonic mean: series resistance of two half-cells
+        const BoutReal C_edge =
+            (std::abs(denom) > std::numeric_limits<BoutReal>::epsilon())
+                ? 2.0 * cond_i * cond_iyp / denom
+                : 0.0;
+
+        const BoutReal flux = C_edge * (fup[iyp] - f[i]);
+
+        result[i] += flux / (coord->dy[i] * coord->J[i]);
+      }
     }
 
     // Calculate flux at lower surface
     if (bndry_flux || mesh->periodicY(i.x()) || !mesh->firstY(i.x())
         || (i.y() != mesh->ystart)) {
-      BoutReal c = 0.5 * (K[i] + Kdown[iym]);           // K at the lower boundary
-      BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
+      BoutReal flux = 0.0;
 
-      BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
+      if constexpr (CONDUCTION_METHOD == 0) {
+        BoutReal c = 0.5 * (K[i] + Kdown[iym]);           // K at the lower boundary
+        BoutReal J = 0.5 * (coord->J[i] + coord->J[iym]); // Jacobian at boundary
+        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
 
-      BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
+        BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
 
-      BoutReal flux = c * J * gradient / g_22;
+        flux = c * J * gradient / g_22;
+      } else if constexpr (CONDUCTION_METHOD == 1) {
+        BoutReal cJ =
+            0.5 * (K[i] * coord->J[i] + Kdown[iym] * coord->J[iym]); // K * J at boundary
+        BoutReal g_22 = 0.5 * (coord->g_22[i] + coord->g_22[iym]);
+
+        BoutReal gradient = 2. * (f[i] - fdown[iym]) / (coord->dy[i] + coord->dy[iym]);
+
+        flux = cJ * gradient / g_22;
+      } else if constexpr (CONDUCTION_METHOD == 2) {
+        const BoutReal cond_i = K[i] * coord->J[i] / (coord->g_22[i] * coord->dy[i]);
+        const BoutReal cond_iym =
+            Kdown[iym] * coord->J[iym] / (coord->g_22[iym] * coord->dy[iym]);
+        const BoutReal denom = cond_i + cond_iym;
+
+        const BoutReal C_edge =
+            (std::abs(denom) > std::numeric_limits<BoutReal>::epsilon())
+                ? 2.0 * cond_i * cond_iym / denom
+                : 0.0;
+
+        flux = C_edge * (f[i] - fdown[iym]);
+      }
 
       result[i] -= flux / (coord->dy[i] * coord->J[i]);
-      flow_ylow[i] = - flux * coord->dx[i] * coord->dz[i];
+      flow_ylow[i] = -flux * coord->dx[i] * coord->dz[i];
     }
   }
 

--- a/src/evolve_density.cxx
+++ b/src/evolve_density.cxx
@@ -246,10 +246,7 @@ void EvolveDensity::transform_impl(GuardedOptions& state) {
 void EvolveDensity::finally(const Options& state) {
 
   const auto& species = state["species"][name];
-
-  // Get density boundary conditions
-  // but retain densities which fall below zero
-  N.setBoundaryTo(get<Field3D>(species["density"]));
+  N = get<Field3D>(species["density"]);
 
   if ((fabs(charge) > 1e-5) and state.isSection("fields")
       and state["fields"].isSet("phi")) {

--- a/src/evolve_pressure.cxx
+++ b/src/evolve_pressure.cxx
@@ -248,9 +248,8 @@ void EvolvePressure::finally(const Options& state) {
   const auto& species = state["species"][name];
 
   // Get updated pressure and temperature with boundary conditions
-  // Note: Retain pressures which fall below zero
+  P = get<Field3D>(species["pressure"]);
   P.clearParallelSlices();
-  P.setBoundaryTo(get<Field3D>(species["pressure"]));
   const Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
 
   T = get<Field3D>(species["temperature"]);

--- a/src/neutral_mixed.cxx
+++ b/src/neutral_mixed.cxx
@@ -317,14 +317,10 @@ void NeutralMixed::finally(const Options& state) {
   // and set boundary conditions on evolved quantities
   Tn = get<Field3D>(localstate["temperature"]);
   Vn = get<Field3D>(localstate["velocity"]);
-  Pn.setBoundaryTo(get<Field3D>(localstate["pressure"]));
-  Nn.setBoundaryTo(get<Field3D>(localstate["density"]));
-  if (!evolve_momentum) {
-    // momentum is not evolved, so need to get the value from the localstate
-    NVn = get<Field3D>(localstate["momentum"]);
-  } else {
-    NVn.setBoundaryTo(get<Field3D>(localstate["momentum"]));
-  }
+  Pn = get<Field3D>(localstate["pressure"]);
+  Nn = get<Field3D>(localstate["density"]);
+  NVn = get<Field3D>(localstate["momentum"]);
+
   // Logarithms used to calculate perpendicular velocity
   // V_perp = -Dnn * ( Grad_perp(Nn)/Nn + Grad_perp(Tn)/Tn )
   //

--- a/tests/unit/fake_mesh.hxx
+++ b/tests/unit/fake_mesh.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bout/boundary_region.hxx>
+#include <bout/boundary_region_iter.hxx>
 #include <bout/bout_types.hxx>
 #include <bout/boutcomm.hxx>
 #include <bout/boutexception.hxx>
@@ -19,6 +20,7 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -95,10 +97,11 @@ public:
 
   // Use this if the FakeMesh needs x- and y-boundaries
   void createBoundaries() {
-    addBoundary(new BoundaryRegionXIn("core", ystart, yend, this));
-    addBoundary(new BoundaryRegionXOut("sol", ystart, yend, this));
-    addBoundary(new BoundaryRegionYUp("upper_target", xstart, xend, this));
-    addBoundary(new BoundaryRegionYDown("lower_target", xstart, xend, this));
+    addBoundary(bout::boundary::NewBoundaryRegionXIn("core", ystart, yend, this));
+    addBoundary(bout::boundary::NewBoundaryRegionXOut("sol", ystart, yend, this));
+    addBoundary(bout::boundary::NewBoundaryRegionYUp("upper_target", xstart, xend, this));
+    addBoundary(
+        bout::boundary::NewBoundaryRegionYDown("lower_target", xstart, xend, this));
   }
 
   comm_handle send(FieldGroup& UNUSED(g)) override { return nullptr; }
@@ -121,6 +124,7 @@ public:
                    [[maybe_unused]] int Z) const override {
     return 0;
   }
+  std::set<std::string> getPossibleBoundaries() const override { return {}; }
   bool firstX() const override { return true; }
   bool lastX() const override { return true; }
   int sendXOut(BoutReal* UNUSED(buffer), int UNUSED(size), int UNUSED(tag)) override {
@@ -171,11 +175,11 @@ public:
   RangeIterator iterateBndryUpperInnerY() const override { return RangeIterator(); }
   bool hasBndryLowerY() const override { return false; }
   bool hasBndryUpperY() const override { return false; }
-  void addBoundary(BoundaryRegion* region) override { boundaries.push_back(region); }
-  std::vector<BoundaryRegion*> getBoundaries() override { return boundaries; }
-  std::vector<std::shared_ptr<BoundaryRegionPar>>
-  getBoundariesPar(BoundaryParType UNUSED(type)) override {
-    return std::vector<std::shared_ptr<BoundaryRegionPar>>();
+  void addBoundary(BoundaryRegionBase* region) override { boundaries.push_back(region); }
+  std::vector<BoundaryRegionBase*> getBoundaries() override { return boundaries; }
+  std::vector<std::shared_ptr<bout::boundary::BoundaryRegionFCI>>
+  getBoundariesPar(BoundaryParType UNUSED(type)) const override {
+    return std::vector<std::shared_ptr<bout::boundary::BoundaryRegionFCI>>();
   }
   BoutReal GlobalX(int jx) const override { return jx; }
   BoutReal GlobalY(int jy) const override { return jy; }
@@ -264,7 +268,7 @@ public:
   using Mesh::msg_len;
 
 private:
-  std::vector<BoundaryRegion*> boundaries;
+  std::vector<BoundaryRegionBase*> boundaries;
 };
 
 /// FakeGridDataSource provides a non-null GridDataSource* source to use with FakeMesh, to


### PR DESCRIPTION
Adds different numerical methods that improve performance in initial tests.
By default nothing changes, but I recommend configuring with:

```
-DHERMES_SLOPE_LIMITER=VanAlbada -DHERMES_CONDUCTION_METHOD=Harmonic
```
More testing is needed before the defaults are changed, but this looks pretty good.

## Parallel conduction

Different interpolations for the conductivity at the cell boundary. 

## Advection slope limiters

Added VanAlbada and WENO3 slope limiters. These are smooth functions of the inputs, hopefully improving solver convergence.