### PR TITLE
Add performance benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,6 +44,7 @@ jobs:
       OMPI_MCA_rmaps_base_oversubscribe: yes
       MPIRUN: mpiexec -np
       LD_LIBRARY_PATH: /home/runner/local/lib:$LD_LIBRARY_PATH
+      ASV_FACTOR: 1.1
 
     steps:
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           # ID of this machine
           uv run --no-project asv machine --yes
-          base_sha="$(git show -s --format='%H' ${{ github.event.pull_request.base.label }})"
+          base_sha="$(git show -s --format='%H' origin/${{ github.base_ref }})"
 
           echo ""
           echo ""

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,63 @@
+# Run the asv benchmarks on this PR, comparing to the base commit
+# Adapted from scikit-image and freegs:
+# https://github.com/scikit-image/scikit-image/blob/main/.github/workflows/benchmarks.yml
+# https://github.com/freegs-plasma/freegs/blob/master/.github/workflows/benchmark.yml
+
+name: Benchmarks
+
+on: pull_request
+
+env:
+  PR_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      # We need the full repo
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements_bench.txt
+
+      - name: Run benchmarks
+        env:
+          ASV_FACTOR: 1.5
+        run: |
+          # ID of this machine
+          asv machine --yes
+
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} ($PR_HEAD_LABEL)"
+
+          # Run benchmarks for current commit against base
+          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
+          asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+              | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
+              | tee benchmarks.log
+
+          # Report and export results for subsequent steps
+          asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
+          if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
+              exit 1
+          fi
+
+      - name: Add instructions to artifact
+        if: always()
+        run: cp benchmarks.log .asv/results/
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: asv-benchmark-results-${{ runner.os }}
+          path: .asv/results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,7 +5,31 @@
 
 name: Benchmarks
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '**,cxx'
+      - '**.hxx'
+      - '**.cmake'
+      - '**.in'
+      - 'CMakeLists.txt'
+      - 'external/BOUT-dev'
+      - 'pyproject.toml'
+      - 'benchmarks/**.py'
+      - 'asv.conf.json'
+      - 'tests/integrated/1D-recycling/data/BOUT.inp'
+      - 'tests/integrated/2D-production/data/BOUT.inp'
+      - 'examples/tokamak-2D-driftplane/2D-drift-plane-turbulence-te-ti/BOUT.inp'
+      - 'tests/integrated/runtest_utils.py'
+      - '.github/workflows/benchmarks.yml'
+      - '!performance/'
+      - '!tests/unit/'
+
+# One run per PR/ref; cancel superseded runs since only the latest
+# push matters
+concurrency:
+   group: performance-benchmark-${{ github.ref }}
+   cancel-in-progress: true
 
 env:
   PR_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
@@ -60,14 +84,12 @@ jobs:
         run: uv sync --only-dev
 
       - name: Run benchmarks
-        env:
-          ASV_FACTOR: 1.5
         run: |
           # ID of this machine
           uv run asv machine --yes
 
-          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
-          echo "Contender: ${GITHUB_SHA} ($PR_HEAD_LABEL)"
+          echo "\n\nBaseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})\n"
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,8 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     env:
-      OMP_NUM_THREADS: ${{ matrix.config.omp_num_threads }}
+      OMP_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
       PYTHONPATH: ${{ github.workspace }}/tools/pylib
       OMPI_MCA_rmaps_base_oversubscribe: yes
       MPIRUN: mpiexec -np

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -87,19 +87,22 @@ jobs:
       - name: Run benchmarks
         run: |
           # ID of this machine
-          uv run asv machine --yes
+          uv run --no-project asv machine --yes
 
-          echo -e "\n\nBaseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
-          echo -e "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})\n"
+          echo ""
+          echo ""
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})"
+          echo ""
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
-          uv run asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+          uv run --no-project asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
               | sed "/Traceback \|failed *$\|PERFORMANCE DECREASED/ s/^/::error::/" \
               | tee benchmarks.log
 
           # Report and export results for subsequent steps
-          uv run asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
+          uv run --no-project asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
           if grep "Traceback \|failed *$\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
               exit 1
           fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -89,8 +89,8 @@ jobs:
           # ID of this machine
           uv run asv machine --yes
 
-          echo "\n\nBaseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
-          echo "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})\n"
+          echo -e "\n\nBaseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo -e "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})\n"
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -88,16 +88,17 @@ jobs:
         run: |
           # ID of this machine
           uv run --no-project asv machine --yes
+          base_sha="$(git show -s --format='%H' ${{ github.event.pull_request.base.label }})"
 
           echo ""
           echo ""
-          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Baseline:  ${base_sha} (${{ github.event.pull_request.base.label }})"
           echo "Contender: ${GITHUB_SHA} (merge of $PR_HEAD_LABEL into ${{ github.event.pull_request.base.label }})"
           echo ""
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
-          uv run --no-project asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+          uv run --no-project asv continuous $ASV_OPTIONS ${base_sha} ${GITHUB_SHA} \
               | sed "/Traceback \|failed *$\|PERFORMANCE DECREASED/ s/^/::error::/" \
               | tee benchmarks.log
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -95,12 +95,12 @@ jobs:
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
           uv run asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
-              | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
+              | sed "/Traceback \|failed *$\|PERFORMANCE DECREASED/ s/^/::error::/" \
               | tee benchmarks.log
 
           # Report and export results for subsequent steps
           uv run asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
-          if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
+          if grep "Traceback \|failed *$\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
               exit 1
           fi
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,29 +51,32 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements_bench.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dev tools
+        run: uv sync --only-dev
 
       - name: Run benchmarks
         env:
           ASV_FACTOR: 1.5
         run: |
           # ID of this machine
-          asv machine --yes
+          uv run asv machine --yes
 
           echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
           echo "Contender: ${GITHUB_SHA} ($PR_HEAD_LABEL)"
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR"
-          asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+          uv run asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
               | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
               | tee benchmarks.log
 
           # Report and export results for subsequent steps
-          asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
+          uv run asv compare --split --factor $ASV_FACTOR ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
           if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
               exit 1
           fi

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,12 +13,37 @@ env:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    env:
+      OMP_NUM_THREADS: ${{ matrix.config.omp_num_threads }}
+      PYTHONPATH: ${{ github.workspace }}/tools/pylib
+      OMPI_MCA_rmaps_base_oversubscribe: yes
+      MPIRUN: mpiexec -np
+      LD_LIBRARY_PATH: /home/runner/local/lib:$LD_LIBRARY_PATH
 
     steps:
+
+      - name: Install dependencies
+        run: sudo apt update &&
+             sudo apt install -y
+                 libfftw3-dev
+                 libnetcdf-dev
+                 libnetcdf-c++4-dev
+                 netcdf-bin
+                 python3
+                 python3-pip
+                 python3-pytest
+                 python3-numpy
+                 python3-scipy
+                 openmpi-bin
+                 libopenmpi-dev
+                 liblapack-dev
+                 libparpack2-dev
+
       # We need the full repo
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ views
 docker/work/
 docker/.env
 docker/docker-compose.override.yaml
+
+# asv-related
+.asv/env/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ BOUT.settings
 .DS_Store
 /build*
 __pycache__
+*.bk
 
 # Docs
 /docs/build
@@ -18,6 +19,9 @@ __pycache__
 
 # IDE config files
 .vscode
+compile_commands.json
+.ccls-cache/
+.cache/clangd/
 
 # spack-related
 spack-build*
@@ -32,4 +36,8 @@ docker/.env
 docker/docker-compose.override.yaml
 
 # asv-related
-.asv/env/
+.asv/
+
+# Python-related directories
+*venv/
+dist/

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,204 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "hermes-3",
+
+    // The project's homepage
+    "project_url": "https://hermes3.readthedocs.io/en/latest/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // "build_command": [
+    //     "cmake {build_dir} -B {build_cache_dir} -DCMAKE_BUILD_TYPE=Release -DPACKAGE_TESTS=OFF --install-prefix {env_dir}",
+    //     "cmake --build {build_cache_dir} -j -- -l 0.9"
+    // ],
+    // "install_command": ["cmake --install {build_cache_dir}"],
+    // "uninstall_command": ["xargs rm < {build_cache_dir}/install_manifest.txt"],
+
+    // FIXME: How best to run this in CI?
+
+    // Customizable commands for building the project.
+    // See asv.conf.json documentation.
+    // To build the package using pyproject.toml (PEP518), uncomment the following lines
+    "build_command": [
+        "python -m pip install build",
+        "python -m build",
+        "python -m pip wheel -w {build_cache_dir} {build_dir}"
+    ],
+    // To build the package using setuptools and a setup.py file, uncomment the following lines
+    // "build_command": [
+    //     "python setup.py build",
+    //     "python -m pip wheel -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // Customizable commands for installing and uninstalling the project.
+    // See asv.conf.json documentation.
+    // "install_command": ["in-dir={env_dir} python -m pip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -m pip uninstall -y {project}"],
+
+    // List of branches to benchmark. If not provided, defaults to "main"
+    // (for git) or "default" (for mercurial).
+    "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv", "rattler", or "uv" or other value depending on the
+    // plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "uv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    "install_timeout": 1200,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/boutproject/hermes-3/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.9", "3.14"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge"],
+
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    "matrix": {
+        "req": {
+            "boutdata": [""]
+        },
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    // "include": [
+    //     // additional env for python3.12
+    //     {"python": "3.12", "req": {"numpy": "1.26"}, "env_nobuild": {"FOO": "123"}},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "3.12", "req": {"libpython": ""}},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+
+    // launch_method:
+    // How to launch benchmarks. Choices: auto, spawn, forkserver
+    // This parameter may be overwritten by command line arguments
+    // "launch_method": "auto",
+}

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -18,21 +18,10 @@
     // of the repository.
     // "repo_subdir": "",
 
-    // "build_command": [
-    //     "cmake {build_dir} -B {build_cache_dir} -DCMAKE_BUILD_TYPE=Release -DPACKAGE_TESTS=OFF --install-prefix {env_dir}",
-    //     "cmake --build {build_cache_dir} -j -- -l 0.9"
-    // ],
-    // "install_command": ["cmake --install {build_cache_dir}"],
-    // "uninstall_command": ["xargs rm < {build_cache_dir}/install_manifest.txt"],
-
-    // FIXME: How best to run this in CI?
-
     // Customizable commands for building the project.
     // See asv.conf.json documentation.
     // To build the package using pyproject.toml (PEP518), uncomment the following lines
     "build_command": [
-        "python -m pip install build",
-        "python -m build",
         "python -m pip wheel -w {build_cache_dir} {build_dir}"
     ],
     // To build the package using setuptools and a setup.py file, uncomment the following lines
@@ -67,7 +56,7 @@
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
-    "install_timeout": 1200,
+    "install_timeout": 2400,
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/boutproject/hermes-3/commit/",

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,83 @@
+import os
+import pathlib
+import sys
+import tempfile
+import shutil
+
+from boututils.run_wrapper import launch_safe
+
+TESTPATH = pathlib.Path(__file__).parent.parent.resolve() / "tests" / "integrated"
+
+
+class Time1DRun:
+    """
+    Simple performance benchmark for 1D case.
+    """
+
+    timeout = 180
+    rounds = 1
+    repeat = 1
+    number = 1
+    warmup_time = 0
+
+    def setup(self):
+        self.rundir = tempfile.TemporaryDirectory()
+        self.runpath = pathlib.Path(self.rundir.name)
+        # FIXME: is this the right test? My notes say 1D-thene
+        shutil.copytree(TESTPATH / "1D-recycling-dthe" / "data", self.runpath / "data")
+        self.cwd = os.getcwd()
+        os.chdir(self.runpath)
+
+    def time_1D_sim(self):
+        launch_safe(
+            f"hermes-3 -d {self.runpath / 'data'} nout=10 timestep=2500", nproc=1
+        )
+
+    def teardown(self):
+        os.chdir(self.cwd)
+        del self.rundir
+
+
+class Time2DRun:
+    """
+    Simple performance benchmark based on running 2D-production
+    """
+
+    timeout = 180
+    rounds = 1
+    repeat = 1
+    number = 1
+    warmup_time = 0
+
+    def setup(self):
+        self.rundir = tempfile.TemporaryDirectory()
+        self.runpath = pathlib.Path(self.rundir.name)
+        testdir = TESTPATH / "2D-production"
+        shutil.copytree(testdir / "data", self.runpath / "data")
+        self.cwd = os.getcwd()
+        os.chdir(self.runpath)
+        # Load the runtest file to access methods needed to download data
+        sys.path.append(str(testdir))
+        # print(testdir / "runtest")
+        # spec = importlib.util.spec_from_file_location("runtest", testdir / "runtest")
+        # assert spec is not None
+        # assert spec.loader is not None
+        # runtest = importlib.util.module_from_spec(spec)
+        # sys.modules["runtest"] = runtest
+        # spec.loader.exec_module(runtest)
+        # Download test data
+        import runtest_utils
+
+        dd = runtest_utils.DataDownloader(self.runpath)
+        dd.download_data()
+        dd.checkHash()
+        dd.extractZip()
+
+    def time_2D_sim(self):
+        launch_safe(
+            f"hermes-3 -d {self.runpath / 'data'} nout=10 timestep=10", nproc=10
+        )
+
+    def teardown(self):
+        os.chdir(self.cwd)
+        del self.rundir

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -4,12 +4,15 @@ import pathlib
 import shutil
 import sys
 import tempfile
-from collections.abc import Callable
 from typing import ClassVar
 
 from boututils.run_wrapper import launch_safe
 
 REPO_BASE = pathlib.Path(__file__).parent.parent.resolve()
+DEFAULT_TESTPATH = REPO_BASE / "tests" / "integrated"
+
+sys.path.append(str(DEFAULT_TESTPATH))
+from runtest_utils import AbstractDataDownloader, DataDownloader2DProduction
 
 
 @dataclasses.dataclass
@@ -18,28 +21,15 @@ class BenchmarkParameters:
     nproc: int
     nout: int
     timestep: float
-    testpath: pathlib.Path = REPO_BASE / "tests" / "integrated"
+    testpath: pathlib.Path = DEFAULT_TESTPATH
     datadir: str = "data"
-    get_data: Callable[["BenchmarkParameters", pathlib.Path], None] = (
-        lambda self, path: None
-    )
+    data_downloader: type[AbstractDataDownloader] | None = None
 
     def __repr__(self) -> str:
         return self.testname
 
 
-def get_2d_production_data(self: BenchmarkParameters, runpath: pathlib.Path):
-    sys.path.append(str(self.testpath / self.testname))
-    import runtest_utils
-
-    sys.path.pop()
-    dd = runtest_utils.DataDownloader(runpath)
-    dd.download_data()
-    dd.checkHash()
-    dd.extractZip()
-
-
-class TimingBenchmark:
+class Simulations:
     timeout = 180
     rounds = 3
     repeat = 1
@@ -49,7 +39,7 @@ class TimingBenchmark:
     params: ClassVar = [
         BenchmarkParameters("1D-recycling-dthe", 1, 10, 2500),
         BenchmarkParameters(
-            "2D-production", 10, 10, 10, get_data=get_2d_production_data
+            "2D-production", 10, 10, 10, data_downloader=DataDownloader2DProduction
         ),
         BenchmarkParameters(
             "tokamak-2D-driftplane",
@@ -70,7 +60,11 @@ class TimingBenchmark:
         )
         self.cwd = os.getcwd()
         os.chdir(self.runpath)
-        param.get_data(param, self.runpath)
+        if param.data_downloader is not None:
+            dd = param.data_downloader(param.testname, self.runpath)
+            dd.download_data()
+            dd.checkHash()
+            dd.extractZip()
 
     def time_sim(self, param: BenchmarkParameters):
         launch_safe(

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,8 +1,8 @@
 import os
 import pathlib
+import shutil
 import sys
 import tempfile
-import shutil
 
 from boututils.run_wrapper import launch_safe
 
@@ -23,7 +23,6 @@ class Time1DRun:
     def setup(self):
         self.rundir = tempfile.TemporaryDirectory()
         self.runpath = pathlib.Path(self.rundir.name)
-        # FIXME: is this the right test? My notes say 1D-thene
         shutil.copytree(TESTPATH / "1D-recycling-dthe" / "data", self.runpath / "data")
         self.cwd = os.getcwd()
         os.chdir(self.runpath)
@@ -58,15 +57,9 @@ class Time2DRun:
         os.chdir(self.runpath)
         # Load the runtest file to access methods needed to download data
         sys.path.append(str(testdir))
-        # print(testdir / "runtest")
-        # spec = importlib.util.spec_from_file_location("runtest", testdir / "runtest")
-        # assert spec is not None
-        # assert spec.loader is not None
-        # runtest = importlib.util.module_from_spec(spec)
-        # sys.modules["runtest"] = runtest
-        # spec.loader.exec_module(runtest)
-        # Download test data
         import runtest_utils
+
+        sys.path.pop()
 
         dd = runtest_utils.DataDownloader(self.runpath)
         dd.download_data()

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,76 +1,83 @@
+import dataclasses
 import os
 import pathlib
 import shutil
 import sys
 import tempfile
+from collections.abc import Callable
+from typing import ClassVar
 
 from boututils.run_wrapper import launch_safe
 
-TESTPATH = pathlib.Path(__file__).parent.parent.resolve() / "tests" / "integrated"
+REPO_BASE = pathlib.Path(__file__).parent.parent.resolve()
 
 
-class Time1DRun:
-    """
-    Simple performance benchmark for 1D case.
-    """
+@dataclasses.dataclass
+class BenchmarkParameters:
+    testname: str
+    nproc: int
+    nout: int
+    timestep: float
+    testpath: pathlib.Path = REPO_BASE / "tests" / "integrated"
+    datadir: str = "data"
+    get_data: Callable[["BenchmarkParameters", pathlib.Path], None] = (
+        lambda self, path: None
+    )
 
+    def __repr__(self) -> str:
+        return self.testname
+
+
+def get_2d_production_data(self: BenchmarkParameters, runpath: pathlib.Path):
+    sys.path.append(str(self.testpath / self.testname))
+    import runtest_utils
+
+    sys.path.pop()
+    dd = runtest_utils.DataDownloader(runpath)
+    dd.download_data()
+    dd.checkHash()
+    dd.extractZip()
+
+
+class TimingBenchmark:
     timeout = 180
-    rounds = 1
+    rounds = 3
     repeat = 1
     number = 1
     warmup_time = 0
 
-    def setup(self):
+    params: ClassVar = [
+        BenchmarkParameters("1D-recycling-dthe", 1, 10, 2500),
+        BenchmarkParameters(
+            "2D-production", 10, 10, 10, get_data=get_2d_production_data
+        ),
+        BenchmarkParameters(
+            "tokamak-2D-driftplane",
+            4,
+            15,
+            250,
+            testpath=REPO_BASE / "examples",
+            datadir="2D-drift-plane-turbulence-te-ti",
+        ),
+    ]
+    param_names: ClassVar = ["testcase"]
+
+    def setup(self, param: BenchmarkParameters):
         self.rundir = tempfile.TemporaryDirectory()
         self.runpath = pathlib.Path(self.rundir.name)
-        shutil.copytree(TESTPATH / "1D-recycling-dthe" / "data", self.runpath / "data")
+        shutil.copytree(
+            param.testpath / param.testname / param.datadir, self.runpath / "data"
+        )
         self.cwd = os.getcwd()
         os.chdir(self.runpath)
+        param.get_data(param, self.runpath)
 
-    def time_1D_sim(self):
+    def time_sim(self, param: BenchmarkParameters):
         launch_safe(
-            f"hermes-3 -d {self.runpath / 'data'} nout=10 timestep=2500", nproc=1
+            f"hermes-3 -d {self.runpath / 'data'} nout={param.nout} timestep={param.timestep}",
+            nproc=param.nproc,
         )
 
-    def teardown(self):
-        os.chdir(self.cwd)
-        del self.rundir
-
-
-class Time2DRun:
-    """
-    Simple performance benchmark based on running 2D-production
-    """
-
-    timeout = 180
-    rounds = 1
-    repeat = 1
-    number = 1
-    warmup_time = 0
-
-    def setup(self):
-        self.rundir = tempfile.TemporaryDirectory()
-        self.runpath = pathlib.Path(self.rundir.name)
-        testdir = TESTPATH / "2D-production"
-        shutil.copytree(testdir / "data", self.runpath / "data")
-        self.cwd = os.getcwd()
-        os.chdir(self.runpath)
-        # Load the runtest file to access methods needed to download data
-        sys.path.append(str(testdir))
-        import runtest_utils
-
-        sys.path.pop()
-
-        dd = runtest_utils.DataDownloader(self.runpath)
-        dd.download_data()
-        dd.checkHash()
-        dd.extractZip()
-
-    def time_2D_sim(self):
-        launch_safe(
-            f"hermes-3 -d {self.runpath / 'data'} nout=10 timestep=10", nproc=10
-        )
-
-    def teardown(self):
+    def teardown(self, param: BenchmarkParameters):
         os.chdir(self.cwd)
         del self.rundir

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -30,7 +30,7 @@ class BenchmarkParameters:
 
 
 class Simulations:
-    timeout = 180
+    timeout = 300
     rounds = 3
     repeat = 1
     number = 1

--- a/docs/sphinx/developer.rst
+++ b/docs/sphinx/developer.rst
@@ -1237,6 +1237,8 @@ The specification of the Toro tests used here is taken from
 originally from Toro's book `Riemann Solvers and Numerical Methods for
 Fluid Dynamics <https://link.springer.com/book/10.1007/b79761>`__.
 
+.. _subsec-1d-recycling-dthe:
+
 1D-recycling-dthe
 ~~~~~~~~~~~~~~~~~
 
@@ -1250,6 +1252,8 @@ exchange channels in the final domain cell against a reference.
 
 The test file can be used to generate the test data if `gen_data` is set to `True` in the beginning
 of the script.
+
+.. _subsec-2d-production:
 
 2D-production
 ~~~~~~~~~~~~~~
@@ -1537,3 +1541,83 @@ across `neutral_mixed`, `evolve_pressure`, `ion_viscosity` and `neutral_parallel
 A minimal 3D geometry is run for one RHS evaluation, and the test checks the log file
 to make sure the correct collisionalities were selected. One of the tests is for the `multispecies`
 mode across all components, while the other is for `braginskii` for plasma and `afn` for neutrals.
+
+.. _sec-benchmarking:
+
+Benchmarking
+------------
+
+`Airspeed Velocity
+<https://asv.readthedocs.io/en/latest/index.html>`__ (``asv``) is used to
+benchmark performance of Hermes-3. The following tests and examples
+are used for this:
+
+- :ref:`subsec-1d-recycling-dthe`
+- :ref:`subsec-2d-production`
+- :ref:`subsec-2d-drift-plane-turbulence-te-ti`
+
+The number and length of timesteps is adjusted so that the benchmarks
+will run for a reasonable length of time. They must run long enough
+that the runtime is not dominated by constructors, but not so long as
+to be inconvenient.
+
+``asv`` was written for use with Python projects and it expects them
+to be installable using typical Python tooling. A `Python wheel
+<https://pythonwheels.com/>`__ (binary package) can be built for
+Hermes-3 using `scikit-build-core
+<https://scikit-build-core.readthedocs.io/en/latest/>`__. This is all
+configured in ``pyproject.toml`` and ``asv`` should be able to build
+and install the wheels automatically. However, this requires all the
+normal Hermes-3 build-dependencies to be findable on your system. See
+the instructions to
+:ref:`sec-hermes-install-spack`/:ref:`sec-install-hermes-3` in a
+``spack`` environment for the simplest way to achieve this. You will
+then need to install ``asv`` itself. This can be done with `uv
+<https://docs.astral.sh/uv/>`__ (various useful linters will also be
+installed).
+
+.. code-block:: bash
+
+   . activate_h3env
+   # Install uv, if not already available on your system
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   # Set up uv workspace with development dependencies
+   uv sync --only-dev
+   # Run asv from within the uv workspace; the first run will take a minute to install it
+   uv run asv --help
+
+You can run ``asv`` on your current commit with the command
+
+.. code-block:: bash
+
+   uv run asv run HEAD
+
+The first time you run ``asv`` benchmarks on a machine, it will prompt
+you for some information about that computer's specifications. It will
+normally be able to detect the information itself, so the defaults
+should be fine.
+
+.. tip::
+
+   Note that ``asv`` can only run against commits; changes to your
+   code that have not been committed will not be included in the
+   benchmarking tests. The exception to this is the ``asv`` *configurations and
+   benchmarking tests themselves*. ``asv`` will use whatever is in the
+   working tree for these.
+
+You can run ``asv`` it on two commits and compare their performance with
+
+.. code-block:: bash
+
+   uv run asv continuous OLDER_COMMIT NEWER_COMMIT
+   uv run asv compare --split OLDER_COMMIT NEWER_COMMIT
+
+This is useful for checking that a branch you are working on hasn't
+introduced any regressions compared to ``master``. ``asv``
+will automatically handle checking out the necessary commits and
+building Hermes-3 for you. It will do all of this in its own directory
+structure and will not make any changes to your repo.
+
+There is a CI workflow which will run these commands comparing each
+Pull Request to its base commit. **The workflow will fail if the
+runtime of any of the benchmarks increases by more than 10%.**

--- a/docs/sphinx/examples.rst
+++ b/docs/sphinx/examples.rst
@@ -25,16 +25,16 @@ In 1D, Hermes-3 follows a single flux tube, typically from midplane to target.
 The code inherits a lot of capability and convention from the code `SD1D
 <https://github.com/boutproject/SD1D/>`_ - see `Dudson 2019
 <https://iopscience.iop.org/article/10.1088/1361-6587/ab1321/meta>`_. for a good description
-of the equations and capabilities. Note that SD1D features a "plasma" pressure equation, 
+of the equations and capabilities. Note that SD1D features a "plasma" pressure equation,
 combining the ion and electron pressures, which are separate in Hermes-3.
 
 There is an `xHermes 1D post-processing example
 <https://github.com/boutproject/xhermes/blob/main/examples/1d-postprocessing.ipynb>`_
 to guide you through results analysis.
 
-For published Hermes-1D applications, see `Body 2024 
+For published Hermes-1D applications, see `Body 2024
 <https://www.sciencedirect.com/science/article/pii/S2352179124002424>`_
-and `Holt 2024 <https://iopscience.iop.org/article/10.1088/1741-4326/ad4f9e/meta>`_. 
+and `Holt 2024 <https://iopscience.iop.org/article/10.1088/1741-4326/ad4f9e/meta>`_.
 
 
 
@@ -112,7 +112,7 @@ The reactions component is a group, which lists the reactions included:
           )
 
 
-.. 
+..
    1D-te-ti
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -124,7 +124,7 @@ The reactions component is a group, which lists the reactions included:
       :name: 1d_te_ti
       :alt:
       :width: 60%
-      
+
       Evolution of pressure, starting from a top hat. Input in ``examples/1D-te-ti``.
 
    To run this example:
@@ -207,10 +207,10 @@ The reactions component is a group, which lists the reactions included:
 Simulations where the dynamics along the magnetic field is not
 included, or only included in a parameterised way as sources or
 sinks. The field line direction is then "into the page", and the
-domain represents a slice somewhere along the field line, e.g. 
+domain represents a slice somewhere along the field line, e.g.
 at the midplane.
 These are useful for the study of the basic physics of plasma
-"blobs" / filaments, and tokamak edge turbulence. 
+"blobs" / filaments, and tokamak edge turbulence.
 
 .. _sec-Blob2d:
 
@@ -225,7 +225,7 @@ closure is used for the parallel current.
    :name: fig-blob2d
    :alt:
    :scale: 50
-   
+
    Electron density Ne at three times, showing propagation to the right
 
 The model components are
@@ -318,7 +318,7 @@ current.
    :name: fig-blob2d-te-ti
    :alt:
    :scale: 50
-   
+
    Electron density Ne at three times, showing propagation to the right and downwards
 
 The model components are
@@ -342,7 +342,7 @@ The ion component sets the ion density from the electron density, by
 using the quasineutrality of the plasma; the ion pressure (``Ph+``) is evolved.
 
 .. code-block:: ini
-   
+
    [h+]
    type = quasineutral, evolve_pressure
 
@@ -360,6 +360,8 @@ now there are pressure equations for both ions and electrons:
    \nabla\cdot\left[\frac{1}{B^2}\nabla_\perp\left(\phi + p_{h+}\right)\right] =& \omega \\
    \nabla\cdot{\mathbf{j}_{sh}} =& \frac{n_e\phi}{L_{||}}
    \end{aligned}
+
+.. _subsec-2d-drift-plane-turbulence-te-ti:
 
 2D-drift-plane-turbulence-te-ti
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -528,7 +530,7 @@ boundary conditions on `Pe`:
 
    [Pe]
    function = 1
-   bndry_core = dirichlet(1.0)  # Core boundary high pressure 
+   bndry_core = dirichlet(1.0)  # Core boundary high pressure
    bndry_all = neumann
 
 That sets the pressure initially uniform, to a normalised value of 1,
@@ -598,9 +600,9 @@ recycling-dthene
 
 Warning
    Impurity transport can be notoriously computationally expensive to run.
-   If you are interested in 2D transport simulations, consider starting 
+   If you are interested in 2D transport simulations, consider starting
    with the much simpler ``recycling`` example (not yet in documentation)
-   
+
 The ``recycling-dthene`` example includes cross-field diffusion,
 parallel flow and heat conduction, collisions between species, sheath
 boundary conditions and recycling. It simulates the density, parallel
@@ -626,14 +628,14 @@ which couple multiple species.
                  recycling, reactions, braginskii_conduction)
 
 Note that long lists like this can be split across multiple lines by
-using parentheses. 
-                 
+using parentheses.
+
 Each ion species has a set of components, to evolve the density,
 momentum and pressure. Anomalous diffusion adds diffusion of
 particles, momentum and energy. For example deuterium ions contain:
 
 .. code-block:: ini
-   
+
    [d+]
    type = evolve_density, evolve_momentum, evolve_pressure, anomalous_diffusion
    AA = 2
@@ -642,7 +644,7 @@ particles, momentum and energy. For example deuterium ions contain:
 Atomic reactions are specified as a list:
 
 .. code-block:: ini
-   
+
    [reactions]
    type = (
         d + e -> d+ + 2e,   # Deuterium ionisation
@@ -738,7 +740,7 @@ divergence of the diamagnetic current is written as
 .. math::
 
    \nabla\cdot\mathbf{J}_d = \nabla\cdot\left[\left(p_e + p_i\right)\nabla\times\frac{\mathbf{b}}{B}\right]
-   
+
 
 
 The input file sets the number of output steps to take and the time
@@ -811,7 +813,5 @@ TCV-X21
 ~~~~~~~~~~~~
 
 An example based on the TCV validation in `Oliveira, Body et al. 2022
-<https://iopscience.iop.org/article/10.1088/1741-4326/ac4cde/meta>`_, 
+<https://iopscience.iop.org/article/10.1088/1741-4326/ac4cde/meta>`_,
 located in located in ``examples\tcv-x21``.
-
-

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -396,6 +396,8 @@ environment file, spack.yaml, to include the gcc installation details.
 
    This workaround should not be required when using spack versions newer than 1.1.0.
 
+.. _sec-install-hermes-3:
+
 Install Hermes-3 and dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 cmake.version = ">=3.25"
 cmake.build-type = "Release"
 wheel.packages = []
-#wheel.install-dir = "${SKBUILD_DATA_DIR}"
+wheel.install-dir = "${SKBUILD_DATA_DIR}"
 sdist.exclude = ["*"]
 sdist.include = ["/README.md", "/LICENSE", "/pyproject.toml", "/src/*.cxx", "/include/*.hxx*", "/hermes-3.cxx", "/hermes-3.hxx",
                  "/CMakeLists.txt", "cmake/**.cmake*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[build-system]
+requires = ["scikit-build-core", "boutdata", "jinja2"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "hermes-3"
+version = "1.5.0"
+
 [dependency-groups]
 dev = [
      "cmake~=4.2",
@@ -14,3 +22,20 @@ dev = [
 ]
 
 [tool.uv.workspace]
+
+[tool.scikit-build]
+cmake.version = ">=3.25"
+cmake.build-type = "Release"
+wheel.packages = []
+#wheel.install-dir = "${SKBUILD_DATA_DIR}"
+sdist.exclude = ["*"]
+sdist.include = ["/README.md", "/LICENSE", "/pyproject.toml", "/src/*.cxx", "/include/*.hxx*", "/hermes-3.cxx", "/hermes-3.hxx",
+                 "/CMakeLists.txt", "cmake/**.cmake*",
+                 "/json_database", "external/BOUT-dev/README.md", "external/BOUT-dev/LICENSE", "external/BOUT-dev/LICENSE.GPL", "external/BOUT-dev/CMakeLists.txt", "external/BOUT-dev/bout++Config.cmake.in", "external/BOUT-dev/cmake_build_defines.hxx.in", "external/BOUT-dev/cmake/*.cmake*", "external/BOUT-dev/bin/bout-config.in", "external/BOUT-dev/tools/pylib/boutconfig/__init__.py.cin", "external/BOUT-dev/src/**/*.cxx", "external/BOUT-dev/src/**/*.hxx",
+                 "external/BOUT-dev/include/bout/**/*.h*", "external/BOUT-dev/externalpackages/cpptrace", "external/BOUT-dev/externalpackages/fmt", "external/BOUT-dev/externalpackages/mpark.variant", "external/BOUT-dev/externalpackages/PVODE", "!external/BOUT-dev/externalpackages/PVODE/source/build-aux", "!external/BOUT-dev/externalpackages/PVODE/precon/build-aux", "!*~", "external/BOUT-dev/src/field/gen_fieldops.jinja", "external/BOUT-dev/src/field/gen_fieldops.py", "external/BOUT-dev/locale", "external/json.hxx"]
+
+[tool.scikit-build.cmake.define]
+BUILD_SHARED_LIBS = false
+BOUT_ENABLE_PYTHON = "OFF"
+HERMES_TESTS = false
+BOUT_BUILD_EXAMPLES = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dev = [
      "ruff~=0.16",
      "sphinx-lint~=1.0",
      "sync-with-uv~=0.6.0",
+     "scikit-build-core~=1.0.3",
+     "asv~=0.6.6",
 ]
 
 [tool.uv.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,16 @@ cmake.version = ">=3.25"
 cmake.build-type = "Release"
 wheel.packages = []
 wheel.install-dir = "${SKBUILD_DATA_DIR}"
-sdist.exclude = ["*"]
-sdist.include = ["/README.md", "/LICENSE", "/pyproject.toml", "/src/*.cxx", "/include/*.hxx*", "/hermes-3.cxx", "/hermes-3.hxx",
-                 "/CMakeLists.txt", "cmake/**.cmake*",
-                 "/json_database", "external/BOUT-dev/README.md", "external/BOUT-dev/LICENSE", "external/BOUT-dev/LICENSE.GPL", "external/BOUT-dev/CMakeLists.txt", "external/BOUT-dev/bout++Config.cmake.in", "external/BOUT-dev/cmake_build_defines.hxx.in", "external/BOUT-dev/cmake/*.cmake*", "external/BOUT-dev/bin/bout-config.in", "external/BOUT-dev/tools/pylib/boutconfig/__init__.py.cin", "external/BOUT-dev/src/**/*.cxx", "external/BOUT-dev/src/**/*.hxx",
-                 "external/BOUT-dev/include/bout/**/*.h*", "external/BOUT-dev/externalpackages/cpptrace", "external/BOUT-dev/externalpackages/fmt", "external/BOUT-dev/externalpackages/mpark.variant", "external/BOUT-dev/externalpackages/PVODE", "!external/BOUT-dev/externalpackages/PVODE/source/build-aux", "!external/BOUT-dev/externalpackages/PVODE/precon/build-aux", "!*~", "external/BOUT-dev/src/field/gen_fieldops.jinja", "external/BOUT-dev/src/field/gen_fieldops.py", "external/BOUT-dev/locale", "external/json.hxx"]
+sdist.exclude = [".github", "scripts", "external/BOUT-spack",
+"googletest", "benchmarks", "ci", "docker", "doc", "docs", "examples",
+"performance", "test", "tests", "external/BOUT-dev/tools",
+"external/BOUT-dev/manual", "build-aux", "external/BOUT-dev/bin",
+"CHANGELOG.md"]
+sdist.include = ["external/BOUT-dev/bin/bout-config.in",
+                 # For some reason this file isn't automatically being included in the SDIST
+                 "external/BOUT-dev/include/bout/build_config.hxx",
+                 "external/BOUT-dev/tools/pylib/boutconfig/__init__.py.cin",
+]
 
 [tool.scikit-build.cmake.define]
 BUILD_SHARED_LIBS = false

--- a/requirements_bench.txt
+++ b/requirements_bench.txt
@@ -1,3 +1,0 @@
-scikit-build-core~=1.0.3
-asv~=0.6.6
-uv

--- a/requirements_bench.txt
+++ b/requirements_bench.txt
@@ -1,0 +1,3 @@
+scikit-build-core~=1.0.3
+asv~=0.6.6
+uv

--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 from boututils.run_wrapper import shell, launch_safe
 import numpy as np
-import shutil
-import zipfile
-import hashlib
 import os
 from pathlib import Path
-import urllib.request
 import xhermes
 from time import time
+from runtest_utils import DataDownloader
 
 t0 = time()
 
@@ -23,84 +20,16 @@ data_dir = this_dir / "data"
 hermes_exec = this_dir.parent.parent.parent / "hermes-3"
 output_path = data_dir / "BOUT.dmp.*.nc"
 
-zipfile_path = this_dir / "test-2D-production.zip"
-url = "https://zenodo.org/records/18696440/files/test-2D-production-2026-02-19.zip"
-expected_hash = "4472d27031a6fcedd30e11360814a66c075f8c14442df745e4e9d80a0dbd87f3"
-expected_filenames = [
-    "BOUT.restart.0.nc",
-    "BOUT.restart.1.nc",
-    "BOUT.restart.2.nc",
-    "BOUT.restart.3.nc",
-    "BOUT.restart.4.nc",
-    "BOUT.restart.5.nc",
-    "BOUT.restart.6.nc",
-    "BOUT.restart.7.nc",
-    "BOUT.restart.8.nc",
-    "BOUT.restart.9.nc",
-    "grid_test2_allpump.nc",
-]
-
-
-def download_data():
-    ## Download files
-    tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
-
-    with urllib.request.urlopen(url, timeout=60) as response:
-        if response.status != 200:
-            raise RuntimeError(
-                f"2D-Production test: download failed - HTTP {response.status}"
-            )
-
-        # Copy bits of the file from response to a temp file
-        # This ensures no partial files are left if the download fails
-        with open(tmp_path, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
-
-    if verbose:
-        print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
-
-    # Rename temp file with the correct name
-    tmp_path.replace(zipfile_path)
-
-
-def extractZip():
-    with zipfile.ZipFile(zipfile_path, "r") as zf:
-        zip_contents = set(zf.namelist())
-        try:
-            # Extract only expected grids
-            for filename in expected_filenames:
-                if filename in zip_contents:
-                    zf.extract(filename, path=this_dir)
-
-        except Exception as e:
-            print("2D-Production test: extracting test grids failed:", e)
-            raise
-
-
-def checkHash(doRaise=True):
-    # Check hash
-    try:
-        with open(zipfile_path, "rb") as f:
-            file_hash = hashlib.sha256(f.read()).hexdigest()
-    except FileNotFoundError:
-        if doRaise:
-            raise
-        return False
-
-    if doRaise:
-        if file_hash != expected_hash:
-            raise RuntimeError(
-                "2D-Production test: downloaded zip file hash does not match expected value"
-            )
-    return file_hash == expected_hash
-
+dd = DataDownloader()
 
 t_download = time()
-if not checkHash(False):
-    download_data()
-    checkHash()
+if not dd.checkHash(False):
+    dd.download_data()
+    if verbose:
+        print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+    dd.checkHash()
 
-extractZip()
+dd.extractZip()
 
 t_extract = time()
 if verbose:

--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -24,7 +24,7 @@ output_path = data_dir / "BOUT.dmp.*.nc"
 sys.path.append(str(this_dir.parent))
 from runtest_utils import DataDownloader2DProduction
 
-dd = DataDownloader2DProduction("2D-Prodcution", this_dir)
+dd = DataDownloader2DProduction("2D-Production", this_dir)
 
 if not dd.checkHash(False):
     dd.download_data()

--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
-import hashlib
 import os
-import shutil
 import sys
-import urllib.request
-import zipfile
-from pathlib import Path
 from time import time
+from runtest_utils import DataDownloader
 
 import numpy as np
 import xhermes
@@ -25,84 +21,16 @@ data_dir = this_dir / "data"
 hermes_exec = this_dir.parent.parent.parent / "hermes-3"
 output_path = data_dir / "BOUT.dmp.*.nc"
 
-zipfile_path = this_dir / "test-2D-production.zip"
-url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
-expected_hash = "f0e02d0599c56a3a95ad28702e50b94ab12bfe3d3b25f6d6a0800851e177cd0c"
-expected_filenames = [
-    "BOUT.restart.0.nc",
-    "BOUT.restart.1.nc",
-    "BOUT.restart.2.nc",
-    "BOUT.restart.3.nc",
-    "BOUT.restart.4.nc",
-    "BOUT.restart.5.nc",
-    "BOUT.restart.6.nc",
-    "BOUT.restart.7.nc",
-    "BOUT.restart.8.nc",
-    "BOUT.restart.9.nc",
-    "grid_test2_allpump.nc",
-]
-
-
-def download_data():
-    ## Download files
-    tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
-
-    with urllib.request.urlopen(url, timeout=60) as response:
-        if response.status != 200:
-            raise RuntimeError(
-                f"2D-Production test: download failed - HTTP {response.status}"
-            )
-
-        # Copy bits of the file from response to a temp file
-        # This ensures no partial files are left if the download fails
-        with open(tmp_path, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
-
-    if verbose:
-        print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
-
-    # Rename temp file with the correct name
-    tmp_path.replace(zipfile_path)
-
-
-def extractZip():
-    with zipfile.ZipFile(zipfile_path, "r") as zf:
-        zip_contents = set(zf.namelist())
-        try:
-            # Extract only expected grids
-            for filename in expected_filenames:
-                if filename in zip_contents:
-                    dest = data_dir if filename.startswith("BOUT.restart") else this_dir
-                    zf.extract(filename, path=dest)
-
-        except Exception as e:
-            print("2D-Production test: extracting test grids failed:", e)
-            raise
-
-
-def checkHash(doRaise=True):
-    # Check hash
-    try:
-        with open(zipfile_path, "rb") as f:
-            file_hash = hashlib.sha256(f.read()).hexdigest()
-    except FileNotFoundError:
-        if doRaise:
-            raise
-        return False
-
-    if doRaise and file_hash != expected_hash:
-        raise RuntimeError(
-            "2D-Production test: downloaded zip file hash does not match expected value"
-        )
-    return file_hash == expected_hash
-
+dd = DataDownloader()
 
 t_download = time()
-if not checkHash(False):
-    download_data()
-    checkHash()
+if not dd.checkHash(False):
+    dd.download_data()
+    if verbose:
+        print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+    dd.checkHash()
 
-extractZip()
+dd.extractZip()
 
 t_extract = time()
 if verbose:

--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -7,7 +7,6 @@ from time import time
 import numpy as np
 import xhermes
 from boututils.run_wrapper import launch_safe, shell
-from runtest_utils import DataDownloader
 
 t0 = time()
 
@@ -22,7 +21,10 @@ data_dir = this_dir / "data"
 hermes_exec = this_dir.parent.parent.parent / "hermes-3"
 output_path = data_dir / "BOUT.dmp.*.nc"
 
-dd = DataDownloader()
+sys.path.append(str(this_dir.parent))
+from runtest_utils import DataDownloader2DProduction
+
+dd = DataDownloader2DProduction("2D-Prodcution", this_dir)
 
 if not dd.checkHash(False):
     dd.download_data()
@@ -30,6 +32,8 @@ if not dd.checkHash(False):
     if verbose:
         print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
     dd.checkHash()
+else:
+    t_download = time()
 
 dd.extractZip()
 

--- a/tests/integrated/2D-production/runtest
+++ b/tests/integrated/2D-production/runtest
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 import os
 import sys
+from pathlib import Path
 from time import time
-from runtest_utils import DataDownloader
 
 import numpy as np
 import xhermes
 from boututils.run_wrapper import launch_safe, shell
+from runtest_utils import DataDownloader
 
 t0 = time()
 
@@ -23,9 +24,9 @@ output_path = data_dir / "BOUT.dmp.*.nc"
 
 dd = DataDownloader()
 
-t_download = time()
 if not dd.checkHash(False):
     dd.download_data()
+    t_download = time()
     if verbose:
         print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
     dd.checkHash()

--- a/tests/integrated/2D-production/runtest_utils.py
+++ b/tests/integrated/2D-production/runtest_utils.py
@@ -1,0 +1,76 @@
+import hashlib
+from pathlib import Path
+import shutil
+import urllib.request
+import zipfile
+
+url = "https://zenodo.org/records/18696440/files/test-2D-production-2026-02-19.zip"
+
+expected_hash = "4472d27031a6fcedd30e11360814a66c075f8c14442df745e4e9d80a0dbd87f3"
+expected_filenames = [
+    "BOUT.restart.0.nc",
+    "BOUT.restart.1.nc",
+    "BOUT.restart.2.nc",
+    "BOUT.restart.3.nc",
+    "BOUT.restart.4.nc",
+    "BOUT.restart.5.nc",
+    "BOUT.restart.6.nc",
+    "BOUT.restart.7.nc",
+    "BOUT.restart.8.nc",
+    "BOUT.restart.9.nc",
+    "grid_test2_allpump.nc",
+]
+
+
+class DataDownloader:
+    def __init__(self, directory=Path(__file__).parent):
+        self.directory = directory
+        self.zipfile_path = self.directory / "test-2D-production.zip"
+
+    def download_data(self):
+        ## Download files
+        tmp_path = self.zipfile_path.with_name(self.zipfile_path.name + ".tmp")
+
+        with urllib.request.urlopen(url, timeout=60) as response:
+            if response.status != 200:
+                raise RuntimeError(
+                    f"2D-Production test: download failed - HTTP {response.status}"
+                )
+
+            # Copy bits of the file from response to a temp file
+            # This ensures no partial files are left if the download fails
+            with open(tmp_path, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
+
+        # Rename temp file with the correct name
+        tmp_path.replace(self.zipfile_path)
+
+    def extractZip(self):
+        with zipfile.ZipFile(self.zipfile_path, "r") as zf:
+            zip_contents = set(zf.namelist())
+            try:
+                # Extract only expected grids
+                for filename in expected_filenames:
+                    if filename in zip_contents:
+                        zf.extract(filename, path=self.directory)
+
+            except Exception as e:
+                print("2D-Production test: extracting test grids failed:", e)
+                raise
+
+    def checkHash(self, doRaise=True):
+        # Check hash
+        try:
+            with open(self.zipfile_path, "rb") as f:
+                file_hash = hashlib.sha256(f.read()).hexdigest()
+        except FileNotFoundError:
+            if doRaise:
+                raise
+            return False
+
+        if doRaise:
+            if file_hash != expected_hash:
+                raise RuntimeError(
+                    "2D-Production test: downloaded zip file hash does not match expected value"
+                )
+        return file_hash == expected_hash

--- a/tests/integrated/2D-production/runtest_utils.py
+++ b/tests/integrated/2D-production/runtest_utils.py
@@ -1,8 +1,8 @@
 import hashlib
-from pathlib import Path
 import shutil
 import urllib.request
 import zipfile
+from pathlib import Path
 
 url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
 
@@ -53,7 +53,11 @@ class DataDownloader:
                 # Extract only expected grids
                 for filename in expected_filenames:
                     if filename in zip_contents:
-                        dest = self.data if filename.startswith("BOUT.restart") else self.directory
+                        dest = (
+                            self.data
+                            if filename.startswith("BOUT.restart")
+                            else self.directory
+                        )
                         zf.extract(filename, path=dest)
             except Exception as e:
                 print("2D-Production test: extracting test grids failed:", e)
@@ -69,9 +73,8 @@ class DataDownloader:
                 raise
             return False
 
-        if doRaise:
-            if file_hash != expected_hash:
-                raise RuntimeError(
-                    "2D-Production test: downloaded zip file hash does not match expected value"
-                )
+        if doRaise and file_hash != expected_hash:
+            raise RuntimeError(
+                "2D-Production test: downloaded zip file hash does not match expected value"
+            )
         return file_hash == expected_hash

--- a/tests/integrated/2D-production/runtest_utils.py
+++ b/tests/integrated/2D-production/runtest_utils.py
@@ -1,0 +1,77 @@
+import hashlib
+from pathlib import Path
+import shutil
+import urllib.request
+import zipfile
+
+url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
+
+expected_hash = "f0e02d0599c56a3a95ad28702e50b94ab12bfe3d3b25f6d6a0800851e177cd0c"
+expected_filenames = [
+    "BOUT.restart.0.nc",
+    "BOUT.restart.1.nc",
+    "BOUT.restart.2.nc",
+    "BOUT.restart.3.nc",
+    "BOUT.restart.4.nc",
+    "BOUT.restart.5.nc",
+    "BOUT.restart.6.nc",
+    "BOUT.restart.7.nc",
+    "BOUT.restart.8.nc",
+    "BOUT.restart.9.nc",
+    "grid_test2_allpump.nc",
+]
+
+
+class DataDownloader:
+    def __init__(self, directory=Path(__file__).parent):
+        self.directory = directory
+        self.data = directory / "data"
+        self.zipfile_path = self.directory / "test-2D-production.zip"
+
+    def download_data(self):
+        ## Download files
+        tmp_path = self.zipfile_path.with_name(self.zipfile_path.name + ".tmp")
+
+        with urllib.request.urlopen(url, timeout=60) as response:
+            if response.status != 200:
+                raise RuntimeError(
+                    f"2D-Production test: download failed - HTTP {response.status}"
+                )
+
+            # Copy bits of the file from response to a temp file
+            # This ensures no partial files are left if the download fails
+            with open(tmp_path, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
+
+        # Rename temp file with the correct name
+        tmp_path.replace(self.zipfile_path)
+
+    def extractZip(self):
+        with zipfile.ZipFile(self.zipfile_path, "r") as zf:
+            zip_contents = set(zf.namelist())
+            try:
+                # Extract only expected grids
+                for filename in expected_filenames:
+                    if filename in zip_contents:
+                        dest = self.data if filename.startswith("BOUT.restart") else self.directory
+                        zf.extract(filename, path=dest)
+            except Exception as e:
+                print("2D-Production test: extracting test grids failed:", e)
+                raise
+
+    def checkHash(self, doRaise=True):
+        # Check hash
+        try:
+            with open(self.zipfile_path, "rb") as f:
+                file_hash = hashlib.sha256(f.read()).hexdigest()
+        except FileNotFoundError:
+            if doRaise:
+                raise
+            return False
+
+        if doRaise:
+            if file_hash != expected_hash:
+                raise RuntimeError(
+                    "2D-Production test: downloaded zip file hash does not match expected value"
+                )
+        return file_hash == expected_hash

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -40,7 +40,7 @@ if not debug:
         dd.download_data()
         t_download = time()
         if verbose:
-            print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+            print(f"2D-recycling test: download took {t_download - t0:.2f} seconds")
         dd.checkHash()
     else:
         t_download = time()
@@ -50,7 +50,7 @@ if not debug:
     t_extract = time()
     if verbose:
         print(
-            f"2D-Production test: zip extraction took {t_extract - t_download:.2f} seconds"
+            f"2D-recycling test: zip extraction took {t_extract - t_download:.2f} seconds"
         )
 
     # Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,

--- a/tests/integrated/2D-recycling/runtest
+++ b/tests/integrated/2D-recycling/runtest
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
-import hashlib
 import os
-import shutil
 import sys
-import urllib.request
-import zipfile
 from pathlib import Path
 from time import time
 
@@ -34,90 +30,27 @@ this_dir = Path(__file__).parent
 data_dir = this_dir / "data"
 output_path = data_dir / "BOUT.dmp.*.nc"
 
-zipfile_path = this_dir / "test-2D-recycling.zip"
-url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
-expected_hash = "f0e02d0599c56a3a95ad28702e50b94ab12bfe3d3b25f6d6a0800851e177cd0c"
-expected_filenames = [
-    "BOUT.restart.0.nc",
-    "BOUT.restart.1.nc",
-    "BOUT.restart.2.nc",
-    "BOUT.restart.3.nc",
-    "BOUT.restart.4.nc",
-    "BOUT.restart.5.nc",
-    "BOUT.restart.6.nc",
-    "BOUT.restart.7.nc",
-    "BOUT.restart.8.nc",
-    "BOUT.restart.9.nc",
-    "grid_test2_allpump.nc",
-]
+sys.path.append(str(this_dir.parent))
+from runtest_utils import DataDownloader2DProduction
 
-
-def download_data():
-    ## Download files
-    tmp_path = zipfile_path.with_name(zipfile_path.name + ".tmp")
-
-    with urllib.request.urlopen(url, timeout=60) as response:
-        if response.status != 200:
-            raise RuntimeError(
-                f"2D-recycling test: download failed - HTTP {response.status}"
-            )
-
-        # Copy bits of the file from response to a temp file
-        # This ensures no partial files are left if the download fails
-        with open(tmp_path, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
-
-    if verbose:
-        print(f"2D-Recycling test: download took {t_download - t0:.2f} seconds")
-
-    # Rename temp file with the correct name
-    tmp_path.replace(zipfile_path)
-
-
-def extractZip():
-    with zipfile.ZipFile(zipfile_path, "r") as zf:
-        zip_contents = set(zf.namelist())
-        try:
-            # Extract only expected grids
-            for filename in expected_filenames:
-                if filename in zip_contents:
-                    dest = data_dir if filename.startswith("BOUT.restart") else this_dir
-                    zf.extract(filename, path=dest)
-
-        except Exception as e:
-            print("2D-recycling test: extracting test grids failed:", e)
-            raise
-
-
-def checkHash(doRaise=True):
-    # Check hash
-    try:
-        with open(zipfile_path, "rb") as f:
-            file_hash = hashlib.sha256(f.read()).hexdigest()
-    except FileNotFoundError:
-        if doRaise:
-            raise
-        return False
-
-    if doRaise and file_hash != expected_hash:
-        raise RuntimeError(
-            "2D-recycling test: downloaded zip file hash does not match expected value"
-        )
-    return file_hash == expected_hash
-
+dd = DataDownloader2DProduction("2D-recycling", this_dir)
 
 if not debug:
-    t_download = time()
-    if not checkHash(False):
-        download_data()
-        checkHash()
+    if not dd.checkHash(False):
+        dd.download_data()
+        t_download = time()
+        if verbose:
+            print(f"2D-Production test: download took {t_download - t0:.2f} seconds")
+        dd.checkHash()
+    else:
+        t_download = time()
 
-    extractZip()
+    dd.extractZip()
 
     t_extract = time()
     if verbose:
         print(
-            f"2D-recycling test: zip extraction took {t_extract - t_download:.2f} seconds"
+            f"2D-Production test: zip extraction took {t_extract - t_download:.2f} seconds"
         )
 
     # Allow oversubscription for OpenMPI via env var (silently ignored by MPICH,
@@ -134,6 +67,7 @@ if not debug:
     t_run = time()
     if verbose:
         print(f"2D-Recycling test: simulation took {t_run - t_extract:.2f}")
+
 
 ##########################################################################
 # Load case and perform test

--- a/tests/integrated/runtest_utils.py
+++ b/tests/integrated/runtest_utils.py
@@ -3,39 +3,40 @@ import shutil
 import urllib.request
 import zipfile
 from pathlib import Path
-
-url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
-
-expected_hash = "f0e02d0599c56a3a95ad28702e50b94ab12bfe3d3b25f6d6a0800851e177cd0c"
-expected_filenames = [
-    "BOUT.restart.0.nc",
-    "BOUT.restart.1.nc",
-    "BOUT.restart.2.nc",
-    "BOUT.restart.3.nc",
-    "BOUT.restart.4.nc",
-    "BOUT.restart.5.nc",
-    "BOUT.restart.6.nc",
-    "BOUT.restart.7.nc",
-    "BOUT.restart.8.nc",
-    "BOUT.restart.9.nc",
-    "grid_test2_allpump.nc",
-]
+from typing import ClassVar
 
 
-class DataDownloader:
-    def __init__(self, directory=Path(__file__).parent):
+class AbstractDataDownloader:
+    url: ClassVar[str]
+    expected_hash: ClassVar[str]
+    expected_filenames: ClassVar[list[str]] = [
+        "BOUT.restart.0.nc",
+        "BOUT.restart.1.nc",
+        "BOUT.restart.2.nc",
+        "BOUT.restart.3.nc",
+        "BOUT.restart.4.nc",
+        "BOUT.restart.5.nc",
+        "BOUT.restart.6.nc",
+        "BOUT.restart.7.nc",
+        "BOUT.restart.8.nc",
+        "BOUT.restart.9.nc",
+        "grid_test2_allpump.nc",
+    ]
+
+    def __init__(self, test_name: str, directory: Path = Path(__file__).parent):
+        self.test_name = test_name
         self.directory = directory
         self.data = directory / "data"
-        self.zipfile_path = self.directory / "test-2D-production.zip"
+        self.zipfile_path = self.directory / f"test-{self.test_name}.zip"
 
     def download_data(self):
         ## Download files
         tmp_path = self.zipfile_path.with_name(self.zipfile_path.name + ".tmp")
 
-        with urllib.request.urlopen(url, timeout=60) as response:
+        with urllib.request.urlopen(self.url, timeout=60) as response:
             if response.status != 200:
                 raise RuntimeError(
-                    f"2D-Production test: download failed - HTTP {response.status}"
+                    f"{self.test_name} test: download failed - HTTP {response.status}"
                 )
 
             # Copy bits of the file from response to a temp file
@@ -51,7 +52,7 @@ class DataDownloader:
             zip_contents = set(zf.namelist())
             try:
                 # Extract only expected grids
-                for filename in expected_filenames:
+                for filename in self.expected_filenames:
                     if filename in zip_contents:
                         dest = (
                             self.data
@@ -60,7 +61,7 @@ class DataDownloader:
                         )
                         zf.extract(filename, path=dest)
             except Exception as e:
-                print("2D-Production test: extracting test grids failed:", e)
+                print(f"{self.test_name} test: extracting test grids failed:", e)
                 raise
 
     def checkHash(self, doRaise=True):
@@ -73,8 +74,13 @@ class DataDownloader:
                 raise
             return False
 
-        if doRaise and file_hash != expected_hash:
+        if doRaise and file_hash != self.expected_hash:
             raise RuntimeError(
-                "2D-Production test: downloaded zip file hash does not match expected value"
+                f"{self.test_name} test: downloaded zip file hash does not match expected value"
             )
-        return file_hash == expected_hash
+        return file_hash == self.expected_hash
+
+
+class DataDownloader2DProduction(AbstractDataDownloader):
+    url = "https://zenodo.org/records/22113649/files/test-2D-production-2026-08-26.zip"
+    expected_hash = "f0e02d0599c56a3a95ad28702e50b94ab12bfe3d3b25f6d6a0800851e177cd0c"


### PR DESCRIPTION
### Purpose
As discussed in #469, we need to be able to track whether changes to Hermes-3 result in performance regressions. This PR adds a basic [airspeed velocity](https://asv.readthedocs.io/en/latest/index.html) setup to perform benchmarking.

### Change Summary
Configurations have been added to run a couple representative cases with Airspeed Velocity (asv). To do this I needed a way to build and install the package into a Python environment. I created a `pyproject.toml` file with a [builder that wraps cmake](https://scikit-build-core.readthedocs.io/en/stable/index.html) to create a Python wheel. There are some kludges, to ensure the hermes-3 executable gets installed in the `bin` directory (rather than a subdirectory of `site-packages`). Ideally we would write this a bit better and maybe integrate it with the machinery that builds wheels for BOUT++. Possibly it could become one of the ways we distribute hermes-3 in future. I also refactored the 2D-production test slightly so I could more easily reuse its routines for downloading test data. This was all done in a bit of a rush and possibly could use some tidying up.

**Warning:** A gotcha that confused me for a while is that asv only benchmarks changes that have been *committed* to your repo (at least by default). Changes that have not been committed will not be run.

### Validation
I have confirmed that ASV can run the benchmarks successfully. I have confirmed that `2D-production` still runs after my refactoring.

### AI Assistance
None.

### Documentation
There are not yet any documentation updates. It would probably be useful to add some instructions to the developer documentation.

### Review Notes
There are still tasks left to complete on this, but I'm going on holiday for two weeks and wanted to share my progress so far before that. These task are

- [x] Create a CI workflow that checks whether a PR creates any performance regressions compared to `master`. This can be done using the [asv continuous](https://asv.readthedocs.io/en/latest/commands.html#asv-continuous) command and/or the [freegs workflow](https://github.com/freegs-plasma/freegs/blob/master/.github/workflows/benchmark.yml) written for this purpose.
- [ ] Develop a workflow for long-term tracking of hermes-3 performance. There are [other repositories](https://github.com/newton-physics/newton-asv/tree/main) with [workflows](https://github.com/newton-physics/newton/blob/main/.github/workflows/aws_gpu_benchmarks.yml) that provide examples of how this can be done. This will require a dedicated server, however, so will be happening on a slightly longer time-horizon.
- [ ] Add a 3D simulation for benchmarking.
- [x] Tweak the number and size of timesteps for the benchmark cases.
- [x] Consider whether it is worth running the benchmarks multiple times for better statistics.
- [ ] Possibly tidy up the Python wheel a bit and create workflows that will build and deploy these for each release.
- [x] Add developer documentation on running benchmarks.

If reviewers would like to implement any of these while I am away they are welcome to do so. Otherwise I can look at them upon my return.