### PR TITLE
Add publications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ manual is [here on
 Readthedocs](https://hermes3.readthedocs.io/en/latest/).
 
 Post-processing Hermes-3 is made easy by using the [xHermes](https://github.com/boutproject/xhermes) Python library.
-xHermes is built on top of [xBOUT](https://github.com/boutproject/xBOUT) and Xarray and automatically accounts 
+xHermes is built on top of [xBOUT](https://github.com/boutproject/xBOUT) and Xarray and automatically accounts
 for the normalisation of Hermes-3 parameters, as well as providing access to many useful xBOUT post-processing functions.
 Many of these are showcased in the [xBOUT examples](https://github.com/boutproject/xBOUT-examples).
 
@@ -31,7 +31,7 @@ All new contributions must be made under the GPLv3 license.
 LLNL-CODE-845139
 
 
-    Copyright Hermes-3 contributors 2017-2025
+    Copyright Hermes-3 contributors 2017-2026
               email: dudson2@llnl.gov
 
     This program is free software: you can redistribute it and/or modify
@@ -113,7 +113,7 @@ for more complicated cases.
 * B.Dudson, M.Kryjak, H.Muhammed, P.Hill, J,Omotani [Hermes-3:
   Multi-component plasma simulations with
   BOUT++](https://doi.org/10.1016/j.cpc.2023.108991)
-  Comp. Phys. Comm. 
+  Comp. Phys. Comm.
   108991 (2023).
   doi:[10.1016/j.cpc.2023.108991](https://doi.org/10.1016/j.cpc.2023.108991).
   Preprint:
@@ -142,3 +142,17 @@ for more complicated cases.
   plasma](https://doi.org/10.1088/1361-6587/ae1bd1) Plasma Phys. Control. Fusion 67 115025 (2025)
   doi:[https://doi.org/10.1088/1361-6587/ae1bd1](https://doi.org/10.1088/1361-6587/ae1bd1)
   Preprint: [arXiv:2509.08178](https://arxiv.org/abs/2509.08178)
+* J. L. Baker, M. Kryjak, M. R. K. Wigram, S. Mijin, D. Power,
+  B. D. Dudson and C. P. Ridgers [The impact of non-local fluid models
+  on 1D impurity driven detachment in an ITER-like
+  SOL](https://doi.org/10.1088/1361-6587/ae56b4) Plasma
+  Phys. Control. Fusion 68(4) 045032 2026
+  doi:[10.1088/1361-6587/ae56b4](https://doi.org/10.1088/1361-6587/ae56b4)
+* M. Robinson, A. Scarabosio, E. Vekshina, J.H. Nichols, J.D. Lore,
+  K. Borowiec, J. Varje, S.M. Levine, M. Scarpari, E.N.J. Maartensson,
+  X. Zhang, R. Kamenicky, J. Alexander, M. Jackson, C. Marsden,
+  S.A.M. McNamara and R. Maingi [Power and particle exhaust in the
+  ST-E1 fusion power
+  plant](https://iopscience.iop.org/article/10.1088/1741-4326/ae70a0#nfae70a0s3)
+  Nucl. Fusion 66 086011 2026
+  doi:[10.1088/1741-4326/ae70a0](https://doi.org/10.1088/1741-4326/ae70a0)

--- a/README.md
+++ b/README.md
@@ -156,3 +156,10 @@ for more complicated cases.
   plant](https://iopscience.iop.org/article/10.1088/1741-4326/ae70a0#nfae70a0s3)
   Nucl. Fusion 66 086011 2026
   doi:[10.1088/1741-4326/ae70a0](https://doi.org/10.1088/1741-4326/ae70a0)
+* Khan, M and Kryjak, M and Cziegler, I and Dudson, B and Henderson, S
+  and Moulton, D and Osawa, R and Ridgers, C P [The role of momentum
+  transfer in the detachment front response to power transients for
+  reactor scale
+  tokamaks](https://iopscience.iop.org/article/10.1088/1741-4326/ae91f8/meta)
+  Nucl. Fusion 66 096032 2026
+  doi:[10.1088/1741-4326/ae91f8](https://doi.org/10.1088/1741-4326/ae91f8)


### PR DESCRIPTION
1D simulations of ITER and ST-E1.

### Purpose
Add recent publications that make use of Hermes-3.

### Change Summary
Only README file changes.

### Validation
Mk1 eyeball.

### AI Assistance
None

### Documentation
Github landing page README

### Review Notes
Other missing publications?
