### PR TITLE
Adjust Braginskii conduction for Fci

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,7 @@ if(HERMES_TESTS)
   hermes_add_integrated_test(1D-density-fci REQUIRES BOUT_ENABLE_METRIC_3D)
   hermes_add_integrated_test(1D-momentum-fci REQUIRES BOUT_ENABLE_METRIC_3D)
   hermes_add_integrated_test(1D-pressure-fci REQUIRES BOUT_ENABLE_METRIC_3D)
+  hermes_add_integrated_test(1D-conduction-fci REQUIRES BOUT_ENABLE_METRIC_3D)
 
   # Unit tests
   option(HERMES_UNIT_TESTS "Build the unit tests" ON)

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -236,7 +236,9 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     // EvolvePressure::finally
 
     Field3D P = GET_VALUE(Field3D, species["pressure"]);
-    P.clearParallelSlices();
+    if (!P.isFci()) {
+      P.clearParallelSlices();
+    }
     const Field3D Pfloor = floor(P, 0.0); // Restricted to never go below zero
     const Field3D T = get<Field3D>(species["temperature"]);
     const Field3D N = get<Field3D>(species["density"]);
@@ -276,18 +278,25 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
       mesh->communicate(kappa_par);
     }
 
-    for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
-      for (int jz = 0; jz < mesh->LocalNz; jz++) {
-        auto i = indexAt(kappa_par, r.ind, mesh->ystart, jz);
-        auto im = i.ym();
-        kappa_par[im] = kappa_par[i];
+    if (P.isFci()) {
+
+      mesh->communicate(kappa_par);
+      kappa_par.applyParallelBoundary("parallel_neumann_o1");
+
+    } else {
+      for (RangeIterator r = mesh->iterateBndryLowerY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(kappa_par, r.ind, mesh->ystart, jz);
+          auto im = i.ym();
+          kappa_par[im] = kappa_par[i];
+        }
       }
-    }
-    for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
-      for (int jz = 0; jz < mesh->LocalNz; jz++) {
-        auto i = indexAt(kappa_par, r.ind, mesh->yend, jz);
-        auto ip = i.yp();
-        kappa_par[ip] = kappa_par[i];
+      for (RangeIterator r = mesh->iterateBndryUpperY(); !r.isDone(); r++) {
+        for (int jz = 0; jz < mesh->LocalNz; jz++) {
+          auto i = indexAt(kappa_par, r.ind, mesh->yend, jz);
+          auto ip = i.yp();
+          kappa_par[ip] = kappa_par[i];
+        }
       }
     }
 

--- a/src/braginskii_conduction.cxx
+++ b/src/braginskii_conduction.cxx
@@ -236,6 +236,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
     // EvolvePressure::finally
 
     Field3D P = GET_VALUE(Field3D, species["pressure"]);
+    // Only clear parallel slices when not Fci
     if (!P.isFci()) {
       P.clearParallelSlices();
     }
@@ -278,6 +279,7 @@ void BraginskiiConduction::transform_impl(GuardedOptions& state) {
       mesh->communicate(kappa_par);
     }
 
+    // Fci does not work with mesh->iterateBndryLowerY(), so set the boundaries differently
     if (P.isFci()) {
 
       mesh->communicate(kappa_par);

--- a/tests/integrated/1D-conduction-fci/data/BOUT.inp
+++ b/tests/integrated/1D-conduction-fci/data/BOUT.inp
@@ -1,0 +1,38 @@
+nout = 50
+timestep = 0.1
+
+
+[mesh]
+
+extrapolate_y = false
+
+[mesh:paralleltransform]
+type = fci
+
+
+[solver]
+mxstep = 10000
+rtol = 1e-5
+atol = 1e-10
+mms = true  # Run with MMS sources and output diagnostics
+mms_initialise = true
+[hermes]
+components = e, braginskii_collisions, braginskii_conduction
+
+
+Nnorm = 1e18
+Bnorm = 1
+Tnorm = 5
+
+[e]
+type = fixed_density, evolve_pressure
+charge = 1.0
+AA = 1.0 / 1836.0
+
+
+density = 3.0e+17*sin(y) + 1.0e+18
+
+[Pe]
+solution = (0.3*sin(y) + 1)*(2.0*sin(y) + 4)
+
+source = 0.252529947526105*sqrt(2)*(0.5*sin(y) + 1)^1.5*(2.0*sin(y) + 4)*cos(y)^2/((0.3*sin(y) + 1)*(-0.5*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 1.25*log(10.0*sin(y) + 20) - 0.5*log(3.0e+17*sin(y) + 1.0e+18) + 30.4)) - 4.16001089238855e-58*sqrt(2)*(0.3*sin(y) + 1)*(0.5*sin(y) + 1)^0.5*(2.0*sin(y) + 4)*cos(y)^2/((1.97680042298754e-58*sin(y) + 6.58933474329179e-58)*(-0.5*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 1.25*log(10.0*sin(y) + 20) - 0.5*log(3.0e+17*sin(y) + 1.0e+18) + 30.4)) - 6.00186243707951e-61*sqrt(2)*(0.3*sin(y) + 1)*(0.5*sin(y) + 1)^1.5*(2.0*sin(y) + 4)*(1.5e+17*cos(y)/(3.0e+17*sin(y) + 1.0e+18) - 12.5*cos(y)/(10.0*sin(y) + 20) + 2.5*(0.5*log(10.0*sin(y) + 20) - 1)*cos(y)/(sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5)*(10.0*sin(y) + 20)))*cos(y)/((1.97680042298754e-58*sin(y) + 6.58933474329179e-58)*(-0.0164473684210526*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 0.0411184210526316*log(10.0*sin(y) + 20) - 0.0164473684210526*log(3.0e+17*sin(y) + 1.0e+18) + 1)^2) + 5.5466811898514e-58*sqrt(2)*(0.3*sin(y) + 1)*(0.5*sin(y) + 1)^1.5*(2.0*sin(y) + 4)*sin(y)/((1.97680042298754e-58*sin(y) + 6.58933474329179e-58)*(-0.5*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 1.25*log(10.0*sin(y) + 20) - 0.5*log(3.0e+17*sin(y) + 1.0e+18) + 30.4)) - 1.10933623797028e-57*sqrt(2)*(0.3*sin(y) + 1)*(0.5*sin(y) + 1)^1.5*cos(y)^2/((1.97680042298754e-58*sin(y) + 6.58933474329179e-58)*(-0.5*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 1.25*log(10.0*sin(y) + 20) - 0.5*log(3.0e+17*sin(y) + 1.0e+18) + 30.4)) - 1.66400435695542e-58*sqrt(2)*(0.5*sin(y) + 1)^1.5*(2.0*sin(y) + 4)*cos(y)^2/((1.97680042298754e-58*sin(y) + 6.58933474329179e-58)*(-0.5*sqrt((0.5*log(10.0*sin(y) + 20) - 1)^2 + 4.0e-5) + 1.25*log(10.0*sin(y) + 20) - 0.5*log(3.0e+17*sin(y) + 1.0e+18) + 30.4))

--- a/tests/integrated/1D-conduction-fci/mms.py
+++ b/tests/integrated/1D-conduction-fci/mms.py
@@ -1,0 +1,106 @@
+from math import pi
+
+import numpy as np
+from boutdata.mms import Div_par, Grad_par, Metric, diff, exprToStr, sin, sqrt, t, y
+from sympy import log
+
+# Length of the y domain
+Ly = 2.0 * pi
+
+# Atomic mass number
+AA = 1.0 / 1836.0
+
+# metric tensor
+metric = Metric()  # Identity
+
+qe = 1.60217663e-19
+Me = 9.1093837e-31
+e0 = 8.85418781e-12
+Pi = pi
+
+Tnorm = 5
+Nnorm = 1e18
+Bnorm = 1.0
+Omega_ci = qe * Bnorm / (1836.0 * Me)
+print(f"Omega_ci = {np.round(Omega_ci, 4)}")
+print(f"seconds = {1.0 / Omega_ci}")
+# Define solution in terms of input x,y,z
+omega = 0.0001
+n = 1 + 0.3 * sin(y)  # * sin(t*omega)
+T = 4 + 2.0 * sin(y)
+p = n * T
+
+# Turn solution into real x and z coordinates
+replace = [(y, metric.y * 2 * pi / Ly)]
+# replace = [ (y, metric.y) ]
+# replace = [ (y, metric.y* Ly / (2.0 * pi)) ]
+
+rho_s = 0.0002284697436697996
+
+n = n.subs(replace)
+T = T.subs(replace)
+p = p.subs(replace)
+
+##############################
+# Calculate time derivatives
+
+
+# Density equation
+dndt = 0.0
+
+
+# Pressure equation
+def coulog(logden, logtemp):
+    return (
+        30.4
+        - 0.5 * logden
+        + (5.0 / 4) * logtemp
+        - sqrt(1e-5 + (logtemp - 2.0) ** 2 / 16.0)
+    )
+
+
+def calc_frequency(den, temp):
+    logden = log(den)
+    logtemp = log(temp)
+
+    coulomb_log = coulog(logden, logtemp)
+    v1sq = 2.0 * temp * qe / Me
+
+    nu = (
+        (qe**4)
+        * den
+        * coulomb_log
+        * 2.0
+        / (3.0 * (Pi * 2.0 * v1sq) ** 1.5 * (e0 * Me) ** 2)
+    )
+
+    return nu / Omega_ci
+
+
+tau = 1.0 / calc_frequency(n * Nnorm, T * Tnorm)
+kappa = (3.16 / sqrt(2)) * p * tau / AA
+dpdt = (2.0 / 3.0) * Div_par(kappa * Grad_par(T)) * (rho_s**2)
+
+#############################
+# Calculate sources
+
+Sn = diff(n, t)  # - dndt
+Sp = diff(p, t) - dpdt
+
+# Substitute back to get input y coordinates
+replace = [(metric.y, y * Ly / (2 * pi))]
+# replace = [ (metric.y, y ) ]
+# replace = [ (metric.y, y*(2*pi) / Ly ) ]
+
+n = n.subs(replace)
+p = p.subs(replace)
+
+Sn = Sn.subs(replace)
+Sp = Sp.subs(replace)
+
+
+print("density = " + exprToStr(n * Nnorm))
+
+print("\n[p]")
+print("solution = " + exprToStr(p))
+print("\nsource = " + exprToStr(Sp))

--- a/tests/integrated/1D-conduction-fci/mms.py
+++ b/tests/integrated/1D-conduction-fci/mms.py
@@ -32,8 +32,6 @@ p = n * T
 
 # Turn solution into real x and z coordinates
 replace = [(y, metric.y * 2 * pi / Ly)]
-# replace = [ (y, metric.y) ]
-# replace = [ (y, metric.y* Ly / (2.0 * pi)) ]
 
 rho_s = 0.0002284697436697996
 
@@ -45,11 +43,7 @@ p = p.subs(replace)
 # Calculate time derivatives
 
 
-# Density equation
-dndt = 0.0
-
-
-# Pressure equation
+# Coulomb logarithm for the calculation of the frequency
 def coulog(logden, logtemp):
     return (
         30.4
@@ -59,6 +53,7 @@ def coulog(logden, logtemp):
     )
 
 
+# Frequency calculation, requires den and temp to NOT be normalized
 def calc_frequency(den, temp):
     logden = log(den)
     logtemp = log(temp)
@@ -73,12 +68,17 @@ def calc_frequency(den, temp):
         * 2.0
         / (3.0 * (Pi * 2.0 * v1sq) ** 1.5 * (e0 * Me) ** 2)
     )
-
+    # Returns NORMALIZED frequency
     return nu / Omega_ci
 
 
+# Collision frequency
 tau = 1.0 / calc_frequency(n * Nnorm, T * Tnorm)
+
+# Heat conduction transport coefficient
 kappa = (3.16 / sqrt(2)) * p * tau / AA
+
+# Pressure equation
 dpdt = (2.0 / 3.0) * Div_par(kappa * Grad_par(T)) * (rho_s**2)
 
 #############################
@@ -89,8 +89,7 @@ Sp = diff(p, t) - dpdt
 
 # Substitute back to get input y coordinates
 replace = [(metric.y, y * Ly / (2 * pi))]
-# replace = [ (metric.y, y ) ]
-# replace = [ (metric.y, y*(2*pi) / Ly ) ]
+
 
 n = n.subs(replace)
 p = p.subs(replace)

--- a/tests/integrated/1D-conduction-fci/runtest
+++ b/tests/integrated/1D-conduction-fci/runtest
@@ -69,38 +69,6 @@ for var in varnames:
     if order < 1.8:
         success = False
 
-# plot errors
-try:
-    import matplotlib.pyplot as plt
-
-    for var in varnames:
-        l2 = results[var]["l2"]
-        inf = results[var]["inf"]
-        order = log(l2[-1] / l2[-2]) / log(dy[-1] / dy[-2])
-
-        plt.plot(dy, l2, "-o", label=r"$l_2$ (" + var + ")")
-        plt.plot(dy, inf, "-x", label=r"$l_\infty$ (" + var + ")")
-        plt.plot(dy, l2[-1] * (dy / dy[-1]) ** order, "--", label=f"Order {order:.1f}")
-
-    plt.legend(loc="upper left")
-    plt.grid()
-
-    plt.yscale("log")
-    plt.xscale("log")
-
-    plt.xlabel(r"Mesh spacing $\delta y$")
-    plt.ylabel("Error norm")
-
-    plt.savefig("fluid_norm.pdf")
-    plt.savefig("fluid_norm.png")
-
-    # plt.show()
-    plt.close()
-except:  # noqa
-    # Plotting could fail for any number of reasons, and the actual
-    # error raised may depend on, among other things, the current
-    # matplotlib backend, so catch everything
-    pass
 
 if success:
     print(" => Test passed")

--- a/tests/integrated/1D-conduction-fci/runtest
+++ b/tests/integrated/1D-conduction-fci/runtest
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# Python script to run and analyse MMS test
+
+import sys
+from pathlib import Path
+
+from boutdata.collect import collect
+from boututils.run_wrapper import launch_safe, shell
+from numpy import abs, array, log, max, mean, sqrt
+
+gridpath = "../../../grids/MMS_slab_y/"
+
+
+def gridname(ny):
+    return gridpath + f"MMS_straight_slab_6_{ny}_4_False.fci.grid.nc"
+
+
+# List of NY values to use
+nylist = [32, 64]
+
+nout = 20
+timestep = 1e4 / nout
+
+nproc = 1
+
+varnames = ["Pe"]
+
+results = {}
+for var in varnames:
+    results[var] = {"l2": [], "inf": []}
+
+for ny in nylist:
+    args = f"mesh:file={gridname(ny)} nout={nout} timestep={timestep}"
+
+    print("Running with " + args)
+
+    # Delete old data
+    shell("rm data/BOUT.dmp.*.nc")
+
+    # Command to run
+    cmd = "../../../hermes-3 " + args
+    # Launch using MPI
+    _, out = launch_safe(cmd, nproc=nproc, pipe=True)
+    Path(f"run.log.{ny}").write_text(out)
+
+    # Collect data
+    for var in varnames:
+        E = collect("E_" + var, tind=[nout, nout], path="data", info=False)
+        E = E[:, 2:-2, :, :]
+
+        l2 = sqrt(mean(E**2))
+        linf = max(abs(E))
+        results[var]["l2"].append(l2)
+        results[var]["inf"].append(linf)
+
+        print(f"Error norm {var}: l-2 {l2:f} l-inf {linf:f}")
+
+# Calculate grid spacing
+dy = 1.0 / array(nylist)
+
+success = True
+
+for var in varnames:
+    l2 = results[var]["l2"]
+    order = log(l2[-1] / l2[-2]) / log(dy[-1] / dy[-2])
+    print(f"Convergence order {var} = {order:f}")
+
+    if order < 1.8:
+        success = False
+
+# plot errors
+try:
+    import matplotlib.pyplot as plt
+
+    for var in varnames:
+        l2 = results[var]["l2"]
+        inf = results[var]["inf"]
+        order = log(l2[-1] / l2[-2]) / log(dy[-1] / dy[-2])
+
+        plt.plot(dy, l2, "-o", label=r"$l_2$ (" + var + ")")
+        plt.plot(dy, inf, "-x", label=r"$l_\infty$ (" + var + ")")
+        plt.plot(dy, l2[-1] * (dy / dy[-1]) ** order, "--", label=f"Order {order:.1f}")
+
+    plt.legend(loc="upper left")
+    plt.grid()
+
+    plt.yscale("log")
+    plt.xscale("log")
+
+    plt.xlabel(r"Mesh spacing $\delta y$")
+    plt.ylabel("Error norm")
+
+    plt.savefig("fluid_norm.pdf")
+    plt.savefig("fluid_norm.png")
+
+    # plt.show()
+    plt.close()
+except:  # noqa
+    # Plotting could fail for any number of reasons, and the actual
+    # error raised may depend on, among other things, the current
+    # matplotlib backend, so catch everything
+    pass
+
+if success:
+    print(" => Test passed")
+    sys.exit(0)
+else:
+    print(" => Test failed")
+    sys.exit(1)


### PR DESCRIPTION
### Purpose
Adjust the Braginskii_conduction component to be functional in Fci. 

### Change Summary

- Not clearing parallel slices when Fci
- Use different boundary approach for kappa_par
- Add MMS test

### Validation
1D Slab MMS test for electron heat conduction

### AI Assistance
None

### Documentation
None

### Review Notes
I am not sure if mesh->communicate(kappa) is needed here to be honest. 
