### PR TITLE
Fix conservation of Lax fluxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ if(HERMES_TESTS)
     endif()
   endfunction()
 
+  hermes_add_integrated_test(1D-density CONFLICTS BOUT_ENABLE_METRIC_3D)
   hermes_add_integrated_test(1D-fluid CONFLICTS BOUT_ENABLE_METRIC_3D)
   hermes_add_integrated_test(1D-recycling CONFLICTS BOUT_ENABLE_METRIC_3D)
   hermes_add_integrated_test(1D-recycling-dthe CONFLICTS BOUT_ENABLE_METRIC_3D)

--- a/docs/sphinx/developer.rst
+++ b/docs/sphinx/developer.rst
@@ -1282,6 +1282,29 @@ This test is a reproduction of C++ code, and therefore there is no golden answer
 This test plots results and can be used to help with developing the recycling component. There
 is a `plot` flag near the beginning of the file.
 
+1D-density (conservation)
+~~~~~~~~~~~~~~
+
+``tests/integrated/1D-density``
+
+This conservation test checks that total particle content of the simulation is conserved on
+a periodic 1D domain while the density is evolved and the temperature and velocity are fixed.
+The test runs four cases: constant temperature and a Heaviside temperature jump, each with and
+without the ``sound_speed`` component, and repeats each case on 1 and 2 MPI ranks.
+
+The script checks three things:
+
+1. total particle content is conserved in this closed periodic system;
+2. the density profile actually changes in time, so the advection path is active;
+3. the final density field matches between the 1-rank and 2-rank runs.
+
+The Heaviside temperature jump is included to stress fluxes that use numerical Lax dissipation
+(see section `Numerics`_), because the wave speed entering that term must be communicated
+consistently across processor boundaries. The constant-temperature cases provide a baseline that
+still checks conservation and MPI decomposition independence. In this testcase the geometry factors
+are constant, so the script checks ``sum(N)`` rather than explicitly evaluating
+:math:`\sum N J\,dx\,dy\,dz`.
+
 1D fluid (MMS)
 ~~~~~~~~~~~~~~
 

--- a/include/fixed_density.hxx
+++ b/include/fixed_density.hxx
@@ -3,6 +3,18 @@
 #define FIXED_DENSITY_H
 
 #include "component.hxx"
+#include "guarded_options.hxx"
+#include "permissions.hxx"
+
+#include <bout/assert.hxx>
+#include <bout/bout_types.hxx>
+#include <bout/field3d.hxx>
+#include <bout/globals.hxx>
+#include <bout/mesh.hxx>
+#include <bout/options.hxx>
+#include <bout/unused.hxx>
+
+#include <string>
 
 /// Set ion density to a fixed value
 ///
@@ -27,8 +39,8 @@ struct FixedDensity : public NamedComponent<FixedDensity> {
     // Get the density and normalise
     N = options["density"].as<Field3D>() / Nnorm;
 
+    bout::globals::mesh->communicate(N);
     if (N.isFci()) {
-      bout::globals::mesh->communicate(N);
       N.applyParallelBoundary("parallel_neumann_o2");
       ASSERT2(N.hasParallelSlices());
     }

--- a/include/fixed_temperature.hxx
+++ b/include/fixed_temperature.hxx
@@ -3,7 +3,18 @@
 #define FIXED_TEMPERATURE_H
 
 #include "component.hxx"
+#include "guarded_options.hxx"
+#include "permissions.hxx"
+
+#include <bout/bout_types.hxx>
 #include <bout/constants.hxx>
+#include <bout/field3d.hxx>
+#include <bout/globals.hxx>
+#include <bout/mesh.hxx>
+#include <bout/options.hxx>
+#include <bout/unused.hxx>
+
+#include <string>
 
 /// Set species temperature to a fixed value
 ///
@@ -27,8 +38,8 @@ struct FixedTemperature : public NamedComponent<FixedTemperature> {
     T = options["temperature"].doc("Constant temperature [eV]").as<Field3D>()
         / Tnorm; // Normalise
 
+    bout::globals::mesh->communicate(T);
     if (T.isFci()) {
-      bout::globals::mesh->communicate(T);
       T.applyParallelBoundary("parallel_neumann_o2");
     }
 

--- a/include/fixed_velocity.hxx
+++ b/include/fixed_velocity.hxx
@@ -3,7 +3,19 @@
 #define FIXED_VELOCITY_H
 
 #include "component.hxx"
+#include "guarded_options.hxx"
+#include "permissions.hxx"
+
+#include <bout/assert.hxx>
+#include <bout/bout_types.hxx>
+#include <bout/boutexception.hxx>
+#include <bout/field3d.hxx>
 #include <bout/globals.hxx>
+#include <bout/mesh.hxx>
+#include <bout/options.hxx>
+#include <bout/unused.hxx>
+
+#include <string>
 
 /// Set parallel velocity to a fixed value
 ///
@@ -33,8 +45,8 @@ struct FixedVelocity : public NamedComponent<FixedVelocity> {
     // so use mesh value (if any) as default value.
     V = options["velocity"].withDefault(V) / Cs0;
 
+    bout::globals::mesh->communicate(V);
     if (V.isFci()) {
-      bout::globals::mesh->communicate(V);
       V.applyParallelBoundary("parallel_neumann_o2");
       ASSERT2(V.hasParallelSlices());
     }

--- a/src/sound_speed.cxx
+++ b/src/sound_speed.cxx
@@ -1,7 +1,16 @@
 
 #include "../include/sound_speed.hxx"
+#include "../include/component.hxx"
+#include "../include/guarded_options.hxx"
 #include "../include/hermes_utils.hxx"
+
+#include <bout/bout_types.hxx>
+#include <bout/field.hxx>
+#include <bout/field3d.hxx>
 #include <bout/mesh.hxx>
+#include <bout/utils.hxx>
+
+#include <cmath>
 
 void SoundSpeed::transform_impl(GuardedOptions& state) {
   Field3D total_pressure = 0.0;
@@ -25,13 +34,14 @@ void SoundSpeed::transform_impl(GuardedOptions& state) {
       auto AA = get<BoutReal>(species["AA"]); // Atomic mass number
 
       if (species.isSet("density")) {
-        total_density += GET_NOBOUNDARY(Field3D, species["density"]) * get<BoutReal>(species["AA"]);
+        total_density +=
+            GET_NOBOUNDARY(Field3D, species["density"]) * get<BoutReal>(species["AA"]);
       }
 
       if (species.isSet("temperature")) {
         auto T = GET_NOBOUNDARY(Field3D, species["temperature"]);
-        for (auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
-          BoutReal sound_speed = sqrt(softFloor(T[i], temperature_floor) / AA);
+        for (const auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
+          const BoutReal sound_speed = sqrt(softFloor(T[i], temperature_floor) / AA);
           fastest_wave[i] = BOUTMAX(fastest_wave[i], sound_speed);
         }
       }
@@ -40,18 +50,20 @@ void SoundSpeed::transform_impl(GuardedOptions& state) {
 
   total_density = softFloor(total_density, 1e-10);
   Field3D sound_speed = sqrt(total_pressure / total_density);
-  for (auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
+  for (const auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
     fastest_wave[i] = BOUTMAX(fastest_wave[i], sound_speed[i]);
   }
 
   if (alfven_wave) {
-    auto *coord = fastest_wave.getCoordinates();
-    for (auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
-      BoutReal alfven_speed = beta_norm * coord->Bxy[i] / sqrt(total_density[i]);
+    auto* coord = fastest_wave.getCoordinates();
+    for (const auto& i : fastest_wave.getRegion("RGN_NOBNDRY")) {
+      const BoutReal alfven_speed = beta_norm * coord->Bxy[i] / sqrt(total_density[i]);
       fastest_wave[i] = BOUTMAX(fastest_wave[i], alfven_speed);
     }
   }
 
+  fastest_wave.getMesh()->communicate(fastest_wave, sound_speed);
+
   set(state["sound_speed"], sound_speed);
-  set(state["fastest_wave"], fastest_wave*fastest_wave_factor);
+  set(state["fastest_wave"], fastest_wave * fastest_wave_factor);
 }

--- a/src/sound_speed.cxx
+++ b/src/sound_speed.cxx
@@ -62,13 +62,11 @@ void SoundSpeed::transform_impl(GuardedOptions& state) {
     }
   }
 
+  // Communicate guard cells
   fastest_wave.getMesh()->communicate(fastest_wave, sound_speed);
-  for (const auto& i : fastest_wave.getRegion("RGN_ALL")) {
-    fastest_wave[i] *= fastest_wave_factor;
-  }
   fastest_wave.resetRegion();
   sound_speed.resetRegion();
 
   set(state["sound_speed"], sound_speed);
-  set(state["fastest_wave"], fastest_wave);
+  set(state["fastest_wave"], fastest_wave * fastest_wave_factor);
 }

--- a/src/sound_speed.cxx
+++ b/src/sound_speed.cxx
@@ -63,7 +63,12 @@ void SoundSpeed::transform_impl(GuardedOptions& state) {
   }
 
   fastest_wave.getMesh()->communicate(fastest_wave, sound_speed);
+  for (const auto& i : fastest_wave.getRegion("RGN_ALL")) {
+    fastest_wave[i] *= fastest_wave_factor;
+  }
+  fastest_wave.resetRegion();
+  sound_speed.resetRegion();
 
   set(state["sound_speed"], sound_speed);
-  set(state["fastest_wave"], fastest_wave * fastest_wave_factor);
+  set(state["fastest_wave"], fastest_wave);
 }

--- a/tests/integrated/1D-density/data/BOUT.inp
+++ b/tests/integrated/1D-density/data/BOUT.inp
@@ -1,20 +1,29 @@
 # Parallel density conservation with and without the sound_speed component.
 #
-# Closed system: the domain is periodic in Y (ixseps1 = ixseps2 = nx), there
-# are no sources and no sheath. The total particle content sum(N * J*dx*dy*dz)
-# is therefore an exact invariant, and any drift is numerical.
+# The runtest script runs four variants of this case:
+#   - constant temperature, without sound_speed
+#   - discontinuous temperature, without sound_speed
+#   - constant temperature, with sound_speed
+#   - discontinuous temperature, with sound_speed
+# and compares 1-processor and 2-processor results.
+#
+# Closed system: the domain is periodic in Y, there are no sources, and there
+# is no sheath. Total particle content sum(N * J * dx * dy * dz) is therefore
+# an exact invariant, and any drift is numerical. In this testcase J and the
+# cell sizes are constant, so the script can check the equivalent sum(N).
 #
 # What it exercises: evolve_density calls
 #   FV::Div_par_mod<Limiter>(N, V, fastest_wave, flow_ylow)
-# (src/evolve_density.cxx:279) with fastest_wave taken from the state, i.e.
-# from the sound_speed component. Div_par_mod builds the Lax dissipation per
-# cell face as amax = BOUTMAX(w(j), w(j+1), ...). The Lax term is active even
-# at V = 0, because it only depends on the density difference across the face.
+# with fastest_wave taken from the state, i.e. from the sound_speed component
+# when it is enabled. Div_par_mod builds the Lax dissipation per cell face as
+# amax = BOUTMAX(w(j), w(j+1), ...), so mismatched wave speeds across a
+# processor boundary can change the density update while still conserving the
+# global particle sum.
 #
-# If the sound_speed component is not present then fastest_wave is calculated
-# in evolve_density using the temperature. If T is not communicated then
-# fastest_wave can be inconsistent between processors (or the two sides
-# of a single processor in a periodic domain)
+# The Heaviside jump in temperature is included to stress the communicated
+# fastest_wave used by the Lax term. The constant-temperature cases provide a
+# baseline that still checks closed-system conservation and MPI decomposition
+# consistency.
 
 nout = 5
 timestep = 1

--- a/tests/integrated/1D-density/data/BOUT.inp
+++ b/tests/integrated/1D-density/data/BOUT.inp
@@ -1,0 +1,57 @@
+# Parallel density conservation with and without the sound_speed component.
+#
+# Closed system: the domain is periodic in Y (ixseps1 = ixseps2 = nx), there
+# are no sources and no sheath. The total particle content sum(N * J*dx*dy*dz)
+# is therefore an exact invariant, and any drift is numerical.
+#
+# What it exercises: evolve_density calls
+#   FV::Div_par_mod<Limiter>(N, V, fastest_wave, flow_ylow)
+# (src/evolve_density.cxx:279) with fastest_wave taken from the state, i.e.
+# from the sound_speed component. Div_par_mod builds the Lax dissipation per
+# cell face as amax = BOUTMAX(w(j), w(j+1), ...). The Lax term is active even
+# at V = 0, because it only depends on the density difference across the face.
+#
+# If the sound_speed component is not present then fastest_wave is calculated
+# in evolve_density using the temperature. If T is not communicated then
+# fastest_wave can be inconsistent between processors (or the two sides
+# of a single processor in a periodic domain)
+
+nout = 5
+timestep = 1
+
+MXG = 0
+
+[mesh]
+
+nx = 1
+ny = 16
+nz = 1
+
+Ly = 1.0
+dy = Ly / ny
+J = 1  # Identity metric
+
+[mesh:paralleltransform]
+type = identity
+
+[hermes]
+components = h+, sound_speed
+
+Nnorm = 1e18
+Bnorm = 1
+Tnorm = 5
+
+normalise_metric = false # Normalise the input metric?
+
+[h+]  # Ions
+type = evolve_density, fixed_velocity, fixed_temperature
+charge = 1.0
+AA = 1.0
+
+temperature = 1.0 + H(y - pi)
+velocity = 0.2 + sin(y)/(0.1*sin(2.0*y) + 1)
+
+[Nh+]
+# Phase offset ensures that extrema are away from processor boundaries
+# so that there is a non-zero Lax flux at those boundaries
+function = 0.4*sin(2.0*y + 0.7) + 1

--- a/tests/integrated/1D-density/runtest
+++ b/tests/integrated/1D-density/runtest
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Python script to run cases and check particle conservation
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from boutdata.collect import collect
+from boututils.run_wrapper import launch_safe, shell
+
+tolerance = 1e-12
+
+# Settings to use
+nylist = [16]
+nprocs = [1, 2]
+settings = [
+    "'hermes:components=h+' 'h+:temperature=1.0'",
+    "'hermes:components=h+' 'h+:temperature=1.0+H(y-pi)'",
+    "'hermes:components=h+, sound_speed' 'h+:temperature=1.0'",
+    "'hermes:components=h+, sound_speed' 'h+:temperature=1.0+H(y-pi)'",
+]
+
+success = True
+
+for nproc in nprocs:
+    for ny in nylist:
+        for ind, setting in enumerate(settings):
+            args = f"mesh:ny={ny} {setting}"
+
+            print(f"Processors {nproc} args " + args)
+
+            # Delete old data
+            shell("rm data/BOUT.dmp.*.nc")
+
+            # Command to run
+            cmd = "../../../hermes-3 " + args
+            # Launch using MPI
+            _, out = launch_safe(cmd, nproc=nproc, pipe=True)
+            Path(f"run.log.{nproc}.{ny}.{ind}").write_text(out)
+
+            # Collect data
+            total_n = np.sum(collect("Nh+", path="data", info=False).squeeze(), axis=-1)
+            err = abs(total_n[-1] - total_n[0])
+            print(f"    Error={err}", end="")
+            if err < tolerance:
+                print(" -> Passed")
+            else:
+                print(" -> Failed")
+                success = False
+
+if success:
+    print(" => Test passed")
+    sys.exit(0)
+else:
+    print(" => Test failed")
+    sys.exit(1)

--- a/tests/integrated/1D-density/runtest
+++ b/tests/integrated/1D-density/runtest
@@ -1,53 +1,130 @@
 #!/usr/bin/env python3
 
-# Python script to run cases and check particle conservation
+# Run a closed 1D density problem and check conservation plus MPI consistency.
 
+import shutil
 import sys
 from pathlib import Path
 
 import numpy as np
 from boutdata.collect import collect
-from boututils.run_wrapper import launch_safe, shell
+from boututils.run_wrapper import launch_safe
 
-tolerance = 1e-12
+conservation_tolerance = 1e-12
+activity_tolerance = 1e-6
+mpi_tolerance = 1e-10
 
 # Settings to use
 nylist = [16]
 nprocs = [1, 2]
 settings = [
-    "'hermes:components=h+' 'h+:temperature=1.0'",
-    "'hermes:components=h+' 'h+:temperature=1.0+H(y-pi)'",
-    "'hermes:components=h+, sound_speed' 'h+:temperature=1.0'",
-    "'hermes:components=h+, sound_speed' 'h+:temperature=1.0+H(y-pi)'",
+    {
+        "name": "temp-constant-no-sound-speed",
+        "args": "'hermes:components=h+' 'h+:temperature=1.0'",
+    },
+    {
+        "name": "temp-jump-no-sound-speed",
+        "args": "'hermes:components=h+' 'h+:temperature=1.0+H(y-pi)'",
+    },
+    {
+        "name": "temp-constant-with-sound-speed",
+        "args": "'hermes:components=h+, sound_speed' 'h+:temperature=1.0'",
+    },
+    {
+        "name": "temp-jump-with-sound-speed",
+        "args": "'hermes:components=h+, sound_speed' 'h+:temperature=1.0+H(y-pi)'",
+    },
 ]
+
+run_root = Path("runs")
+input_file = Path("data/BOUT.inp")
+results = {}
+hermes_candidates = [Path("../../../hermes-3"), Path("../../../build/hermes-3")]
+hermes_exec = next((path for path in hermes_candidates if path.exists()), None)
+
+if hermes_exec is None:
+    raise FileNotFoundError("Could not find hermes-3 executable in repo root or build/")
+
+
+def run_case(nproc, ny, setting):
+    args = f"mesh:ny={ny} {setting['args']}"
+    case_dir = run_root / f"{setting['name']}.np{nproc}.ny{ny}"
+
+    print(f"Processors {nproc} args {args}")
+
+    if case_dir.exists():
+        shutil.rmtree(case_dir)
+    case_dir.mkdir(parents=True)
+    shutil.copy(input_file, case_dir / "BOUT.inp")
+
+    status, out = launch_safe(
+        f"{hermes_exec} -d {case_dir} {args}", nproc=nproc, pipe=True
+    )
+    (case_dir / "run.log").write_text(out)
+
+    if status != 0:
+        raise RuntimeError(f"Hermes run failed for {case_dir}")
+
+    density = np.asarray(collect("Nh+", path=str(case_dir), info=False)).squeeze()
+    density = np.atleast_2d(density)
+
+    total_n = np.sum(density.reshape(density.shape[0], -1), axis=1)
+    conservation_error = abs(total_n[-1] - total_n[0])
+    max_change = np.max(np.abs(density[-1] - density[0]))
+
+    print(f"    Conservation error={conservation_error}", end="")
+    if conservation_error < conservation_tolerance:
+        print(" -> Passed")
+    else:
+        print(" -> Failed")
+
+    print(f"    Max field change={max_change}", end="")
+    if max_change > activity_tolerance:
+        print(" -> Passed")
+    else:
+        print(" -> Failed")
+
+    return {
+        "case_dir": case_dir,
+        "final_density": density[-1].copy(),
+        "conservation_error": conservation_error,
+        "max_change": max_change,
+    }
+
 
 success = True
 
 for nproc in nprocs:
     for ny in nylist:
-        for ind, setting in enumerate(settings):
-            args = f"mesh:ny={ny} {setting}"
+        for setting in settings:
+            case_result = run_case(nproc, ny, setting)
+            results[(ny, setting["name"], nproc)] = case_result
 
-            print(f"Processors {nproc} args " + args)
-
-            # Delete old data
-            shell("rm data/BOUT.dmp.*.nc")
-
-            # Command to run
-            cmd = "../../../hermes-3 " + args
-            # Launch using MPI
-            _, out = launch_safe(cmd, nproc=nproc, pipe=True)
-            Path(f"run.log.{nproc}.{ny}.{ind}").write_text(out)
-
-            # Collect data
-            total_n = np.sum(collect("Nh+", path="data", info=False).squeeze(), axis=-1)
-            err = abs(total_n[-1] - total_n[0])
-            print(f"    Error={err}", end="")
-            if err < tolerance:
-                print(" -> Passed")
-            else:
-                print(" -> Failed")
+            if case_result["conservation_error"] >= conservation_tolerance:
                 success = False
+            if case_result["max_change"] <= activity_tolerance:
+                success = False
+
+for ny in nylist:
+    for setting in settings:
+        serial_result = results[(ny, setting["name"], 1)]
+        parallel_result = results[(ny, setting["name"], 2)]
+        mpi_diff = np.max(
+            np.abs(serial_result["final_density"] - parallel_result["final_density"])
+        )
+
+        print(f"MPI consistency {setting['name']} ny={ny}: max diff={mpi_diff}", end="")
+        if mpi_diff < mpi_tolerance:
+            print(" -> Passed")
+        else:
+            print(" -> Failed")
+            print(
+                "    Serial output:",
+                serial_result["case_dir"],
+                "Parallel output:",
+                parallel_result["case_dir"],
+            )
+            success = False
 
 if success:
     print(" => Test passed")

--- a/tests/unit/test_sound_speed.cxx
+++ b/tests/unit/test_sound_speed.cxx
@@ -20,6 +20,7 @@ using namespace bout::globals;
 
 namespace {
 
+/// Construct normalized units and component options for SoundSpeed tests.
 Options makeSoundSpeedOptions(BoutReal Bnorm = 1.0, BoutReal Nnorm = 1.0,
                               BoutReal Lnorm = 1.0, BoutReal tnorm = 1.0,
                               BoutReal eVnorm = 1.0, bool alfven_wave = false,
@@ -40,6 +41,7 @@ Options makeSoundSpeedOptions(BoutReal Bnorm = 1.0, BoutReal Nnorm = 1.0,
   return options;
 }
 
+/// Create a Field3D that varies only in Y, with constant X and Z planes.
 Field3D makeYField(const std::vector<BoutReal>& yvalues) {
   EXPECT_EQ(static_cast<int>(yvalues.size()), mesh->LocalNy);
 
@@ -55,6 +57,11 @@ Field3D makeYField(const std::vector<BoutReal>& yvalues) {
   return result;
 }
 
+/// Calculate the normalization factor used for the Alfven-speed comparison.
+///
+/// Takes `Tesla`, `inv_meters_cubed`, `meters`, and `seconds` from `options["units"]`
+/// and returns the factor that multiplies `Bxy / sqrt(total_density)` in
+/// `SoundSpeed::transform_impl()`.
 BoutReal getBetaNorm(const Options& options) {
   const auto& units = options["units"];
   return get<BoutReal>(units["Tesla"])
@@ -62,6 +69,10 @@ BoutReal getBetaNorm(const Options& options) {
          / (get<BoutReal>(units["meters"]) / get<BoutReal>(units["seconds"]));
 }
 
+/// FakeMesh variant whose Y communication wraps edge values into guard cells.
+///
+/// This lets the periodic-boundary test verify the post-communication state of
+/// `sound_speed` and `fastest_wave` without needing a full distributed mesh.
 class PeriodicCommFakeMesh : public FakeMesh {
 public:
   PeriodicCommFakeMesh(int nx, int ny, int nz, MpiWrapper& mpi_in)
@@ -98,6 +109,7 @@ private:
   std::vector<Field3D*> pending_fields;
 };
 
+/// Fixture with a simple metric and periodic Y communication.
 class PeriodicCommSoundSpeedTest : public ::testing::Test {
 public:
   PeriodicCommSoundSpeedTest()
@@ -149,7 +161,9 @@ private:
 // Reuse the "standard" fixture for FakeMesh
 using SoundSpeedTest = FakeMeshFixture;
 
-TEST_F(SoundSpeedTest, OneSpeciesSetsSoundSpeedAndFastestWaveInBoundaryCells) {
+/// Baseline case: with one species, both outputs reduce to that species'
+/// collective sound speed in the interior region (`RGN_NOBNDRY`).
+TEST_F(SoundSpeedTest, OneSpeciesSetsSoundSpeedAndFastestWaveInInteriorCells) {
   Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
 
@@ -169,6 +183,8 @@ TEST_F(SoundSpeedTest, OneSpeciesSetsSoundSpeedAndFastestWaveInBoundaryCells) {
       IsFieldEqual(get<Field3D>(options["fastest_wave"]), expected, "RGN_NOBNDRY"));
 }
 
+/// With multiple species and no temperature-driven species maximum, both outputs
+/// use the collective sound speed sqrt(sum(pressure) / sum(density * AA)).
 TEST_F(SoundSpeedTest, TwoSpeciesCollectiveSoundSpeed) {
   Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
@@ -193,6 +209,8 @@ TEST_F(SoundSpeedTest, TwoSpeciesCollectiveSoundSpeed) {
       IsFieldEqual(get<Field3D>(options["fastest_wave"]), expected, "RGN_NOBNDRY"));
 }
 
+/// `sound_speed` stays equal to the collective value, while `fastest_wave`
+/// tracks the pointwise maximum of the collective and per-species thermal speeds.
 TEST_F(SoundSpeedTest, FastestWaveIsMaximumOfSpeciesAndCollectiveSoundSpeeds) {
   Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
@@ -200,6 +218,9 @@ TEST_F(SoundSpeedTest, FastestWaveIsMaximumOfSpeciesAndCollectiveSoundSpeeds) {
   options["species"]["h+"]["density"] = 1.0;
   options["species"]["h+"]["pressure"] = 8.0;
   options["species"]["h+"]["AA"] = 1.0;
+  // Vary temperature while keeping pressure fixed so only the per-species thermal
+  // speed changes; this makes `fastest_wave` exceed the collective sound speed
+  // in selected interior cells.
   options["species"]["h+"]["temperature"] = makeYField({1.0, 1.0, 4.0, 9.0, 9.0});
 
   options["species"]["he+"]["density"] = 1.0;
@@ -215,6 +236,8 @@ TEST_F(SoundSpeedTest, FastestWaveIsMaximumOfSpeciesAndCollectiveSoundSpeeds) {
                            makeYField({0.0, 2.0, 2.0, 3.0, 0.0}), "RGN_NOBNDRY"));
 }
 
+/// When `alfven_wave` is enabled but the Alfven speed is below the collective
+/// sound speed, `fastest_wave` should remain equal to `sound_speed`.
 TEST_F(SoundSpeedTest, AlfvenWaveUsesSoundSpeedAtHighBeta) {
   Options options = makeSoundSpeedOptions(1.0, 1e38, 1e19, 1.0, 1.0, true);
   SoundSpeed component("test", options, nullptr);
@@ -237,6 +260,8 @@ TEST_F(SoundSpeedTest, AlfvenWaveUsesSoundSpeedAtHighBeta) {
       IsFieldEqual(get<Field3D>(options["fastest_wave"]), sound_speed, "RGN_NOBNDRY"));
 }
 
+/// When the Alfven speed exceeds the collective sound speed, `fastest_wave`
+/// should switch to the Alfven branch while `sound_speed` stays unchanged.
 TEST_F(SoundSpeedTest, AlfvenWaveUsesAlfvenSpeedAtLowBeta) {
   Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, true);
   SoundSpeed component("test", options, nullptr);
@@ -259,6 +284,9 @@ TEST_F(SoundSpeedTest, AlfvenWaveUsesAlfvenSpeedAtLowBeta) {
       IsFieldEqual(get<Field3D>(options["fastest_wave"]), alfven_speed, "RGN_NOBNDRY"));
 }
 
+/// Disabling `electron_dynamics` skips the electron species when building the
+/// per-species maximum for `fastest_wave`, but still includes electron pressure
+/// in the collective `sound_speed`.
 TEST_F(SoundSpeedTest, ElectronDynamicsFalseExcludesElectronSpeciesSoundSpeed) {
   Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, false, false);
   SoundSpeed component("test", options, nullptr);
@@ -280,6 +308,8 @@ TEST_F(SoundSpeedTest, ElectronDynamicsFalseExcludesElectronSpeciesSoundSpeed) {
   ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]), 3.0, "RGN_NOBNDRY"));
 }
 
+/// `fastest_wave_factor` is applied only to the final `fastest_wave` output and
+/// must not change the separately reported `sound_speed`.
 TEST_F(SoundSpeedTest, FastestWaveFactorScalesFastestWaveOnly) {
   Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, false, true, 1.7);
   SoundSpeed component("test", options, nullptr);
@@ -295,6 +325,8 @@ TEST_F(SoundSpeedTest, FastestWaveFactorScalesFastestWaveOnly) {
   ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]), 3.4, "RGN_NOBNDRY"));
 }
 
+/// On a non-periodic mesh, Y boundary values should be overwritten by boundary
+/// handling rather than preserving the supplied edge-cell inputs.
 TEST_F(SoundSpeedTest, NonPeriodicBoundaryCellsAreSet) {
   auto* fake_mesh = dynamic_cast<FakeMesh*>(mesh);
   ASSERT_NE(fake_mesh, nullptr);
@@ -303,6 +335,8 @@ TEST_F(SoundSpeedTest, NonPeriodicBoundaryCellsAreSet) {
   Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
 
+  // Seed distinct edge values so the test can tell whether boundary handling
+  // overwrites them with the expected interior-adjacent values.
   const Field3D input = makeYField({25.0, 4.0, 9.0, 16.0, 36.0});
 
   options["species"]["i"]["density"] = 1.0;
@@ -326,6 +360,8 @@ TEST_F(SoundSpeedTest, NonPeriodicBoundaryCellsAreSet) {
   }
 }
 
+/// On a periodic mesh, Y guard cells should be populated by communication from
+/// the opposite interior edge after `sound_speed` and `fastest_wave` are computed.
 TEST_F(PeriodicCommSoundSpeedTest, PeriodicGuardCellsAreCommunicated) {
   Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);

--- a/tests/unit/test_sound_speed.cxx
+++ b/tests/unit/test_sound_speed.cxx
@@ -1,10 +1,12 @@
-
 #include "gtest/gtest.h"
 
 #include "fake_mesh_fixture.hxx"
 #include "test_extras.hxx" // FakeMesh
 
 #include "../../include/sound_speed.hxx"
+
+#include <memory>
+#include <vector>
 
 /// Global mesh
 namespace bout {
@@ -16,11 +18,139 @@ extern Mesh* mesh;
 // The unit tests use the global mesh
 using namespace bout::globals;
 
+namespace {
+
+Options makeSoundSpeedOptions(BoutReal Bnorm = 1.0, BoutReal Nnorm = 1.0,
+                              BoutReal Lnorm = 1.0, BoutReal tnorm = 1.0,
+                              BoutReal eVnorm = 1.0, bool alfven_wave = false,
+                              bool electron_dynamics = true,
+                              BoutReal fastest_wave_factor = 1.0) {
+  Options options;
+  options["units"]["Tesla"] = Bnorm;
+  options["units"]["inv_meters_cubed"] = Nnorm;
+  options["units"]["meters"] = Lnorm;
+  options["units"]["seconds"] = tnorm;
+  options["units"]["eV"] = eVnorm;
+
+  Options& component = options["test"];
+  component["alfven_wave"] = alfven_wave;
+  component["electron_dynamics"] = electron_dynamics;
+  component["fastest_wave_factor"] = fastest_wave_factor;
+
+  return options;
+}
+
+Field3D makeYField(const std::vector<BoutReal>& yvalues) {
+  EXPECT_EQ(static_cast<int>(yvalues.size()), mesh->LocalNy);
+
+  Field3D result(0.0);
+  for (int x = 0; x < mesh->LocalNx; ++x) {
+    for (int y = 0; y < mesh->LocalNy; ++y) {
+      for (int z = 0; z < mesh->LocalNz; ++z) {
+        result(x, y, z) = yvalues[static_cast<size_t>(y)];
+      }
+    }
+  }
+
+  return result;
+}
+
+BoutReal getBetaNorm(const Options& options) {
+  const auto& units = options["units"];
+  return get<BoutReal>(units["Tesla"])
+         / sqrt(SI::mu0 * get<BoutReal>(units["inv_meters_cubed"]) * SI::Mp)
+         / (get<BoutReal>(units["meters"]) / get<BoutReal>(units["seconds"]));
+}
+
+class PeriodicCommFakeMesh : public FakeMesh {
+public:
+  PeriodicCommFakeMesh(int nx, int ny, int nz, MpiWrapper& mpi_in)
+      : FakeMesh(nx, ny, nz, mpi_in) {}
+
+  comm_handle send(FieldGroup& g) override {
+    pending_fields = g.field3d();
+    return reinterpret_cast<comm_handle>(this);
+  }
+
+  comm_handle sendY(FieldGroup& g, comm_handle UNUSED(handle) = nullptr) override {
+    pending_fields = g.field3d();
+    return reinterpret_cast<comm_handle>(this);
+  }
+
+  int wait(comm_handle UNUSED(handle)) override {
+    for (auto* field : pending_fields) {
+      for (int x = 0; x < LocalNx; ++x) {
+        if (!periodicY(x)) {
+          continue;
+        }
+        for (int z = 0; z < LocalNz; ++z) {
+          (*field)(x, ystart - 1, z) = (*field)(x, yend, z);
+          (*field)(x, yend + 1, z) = (*field)(x, ystart, z);
+        }
+      }
+    }
+
+    pending_fields.clear();
+    return 0;
+  }
+
+private:
+  std::vector<Field3D*> pending_fields;
+};
+
+class PeriodicCommSoundSpeedTest : public ::testing::Test {
+public:
+  PeriodicCommSoundSpeedTest()
+      : mesh_m(3, 5, 7, mpi), quiet_info(output_info), quiet_warn(output_warn) {
+    bout::globals::mpi = &mpi;
+    bout::globals::mesh = &mesh_m;
+    bout::globals::mesh->createDefaultRegions();
+    mesh_m.setCoordinates(nullptr);
+
+    test_coords = std::make_shared<Coordinates>(
+        bout::globals::mesh, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0}, Field2D{0.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{1.0}, Field2D{1.0}, Field2D{1.0},
+        Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0}, Field2D{0.0});
+
+    test_coords->G1 = test_coords->G2 = test_coords->G3 = 0.1;
+    test_coords->non_uniform = true;
+    test_coords->d1_dx = test_coords->d1_dy = 0.2;
+    test_coords->d1_dz = 0.0;
+#if BOUT_USE_METRIC_3D
+    test_coords->Bxy.splitParallelSlices();
+    test_coords->Bxy.yup() = test_coords->Bxy.ydown() = test_coords->Bxy;
+#endif
+
+    mesh_m.setGridDataSource(new FakeGridDataSource());
+    test_coords->setParallelTransform(
+        bout::utils::make_unique<ParallelTransformIdentity>(*bout::globals::mesh));
+    mesh_m.setCoordinates(test_coords);
+    mesh_m.createBoundaryRegions();
+  }
+
+  ~PeriodicCommSoundSpeedTest() override {
+    bout::globals::mesh = nullptr;
+    bout::globals::mpi = nullptr;
+
+    Options::cleanup();
+  }
+
+private:
+  PeriodicCommFakeMesh mesh_m;
+  std::shared_ptr<Coordinates> test_coords{nullptr};
+  MpiWrapper mpi;
+  WithQuietOutput quiet_info;
+  WithQuietOutput quiet_warn;
+};
+
+} // namespace
+
 // Reuse the "standard" fixture for FakeMesh
 using SoundSpeedTest = FakeMeshFixture;
 
-TEST_F(SoundSpeedTest, OneSpecies) {
-  Options options;
+TEST_F(SoundSpeedTest, OneSpeciesSetsSoundSpeedAndFastestWaveInBoundaryCells) {
+  Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
 
   options["species"]["e"]["density"] = 2.0;
@@ -30,13 +160,17 @@ TEST_F(SoundSpeedTest, OneSpecies) {
   component.declareAllSpecies({"e"});
   component.transform(options);
 
+  const BoutReal expected = sqrt(1.2 / (2.0 * 1.5));
+
   ASSERT_TRUE(options.isSet("sound_speed"));
-  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["sound_speed"]), sqrt(1.2 / (2.0 * 1.5)),
-                           "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["sound_speed"]), expected, "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["fastest_wave"]), expected, "RGN_NOBNDRY"));
 }
 
-TEST_F(SoundSpeedTest, TwoSpecies) {
-  Options options;
+TEST_F(SoundSpeedTest, TwoSpeciesCollectiveSoundSpeed) {
+  Options options = makeSoundSpeedOptions();
   SoundSpeed component("test", options, nullptr);
 
   options["species"]["e"]["density"] = 2.0;
@@ -50,7 +184,176 @@ TEST_F(SoundSpeedTest, TwoSpecies) {
   component.declareAllSpecies({"e", "h"});
   component.transform(options);
 
+  const BoutReal expected = sqrt((1.2 + 2.5) / (2.0 * 1.5 + 3.0 * 0.9));
+
   ASSERT_TRUE(options.isSet("sound_speed"));
-  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["sound_speed"]),
-                           sqrt((1.2 + 2.5) / (2.0 * 1.5 + 3.0 * 0.9)), "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["sound_speed"]), expected, "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["fastest_wave"]), expected, "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, FastestWaveIsMaximumOfSpeciesAndCollectiveSoundSpeeds) {
+  Options options = makeSoundSpeedOptions();
+  SoundSpeed component("test", options, nullptr);
+
+  options["species"]["h+"]["density"] = 1.0;
+  options["species"]["h+"]["pressure"] = 8.0;
+  options["species"]["h+"]["AA"] = 1.0;
+  options["species"]["h+"]["temperature"] = makeYField({1.0, 1.0, 4.0, 9.0, 9.0});
+
+  options["species"]["he+"]["density"] = 1.0;
+  options["species"]["he+"]["pressure"] = 12.0;
+  options["species"]["he+"]["AA"] = 4.0;
+  options["species"]["he+"]["temperature"] = 1.0;
+
+  component.declareAllSpecies({"h+", "he+"});
+  component.transform(options);
+
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["sound_speed"]), 2.0, "RGN_NOBNDRY"));
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]),
+                           makeYField({0.0, 2.0, 2.0, 3.0, 0.0}), "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, AlfvenWaveUsesSoundSpeedAtHighBeta) {
+  Options options = makeSoundSpeedOptions(1.0, 1e38, 1e19, 1.0, 1.0, true);
+  SoundSpeed component("test", options, nullptr);
+
+  mesh->getCoordinates()->Bxy = 1.0;
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = 4.0;
+  options["species"]["i"]["AA"] = 1.0;
+
+  component.declareAllSpecies({"i"});
+  component.transform(options);
+
+  const BoutReal sound_speed = 2.0;
+  const BoutReal alfven_speed = getBetaNorm(options);
+
+  ASSERT_LT(alfven_speed, sound_speed);
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["sound_speed"]), sound_speed, "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["fastest_wave"]), sound_speed, "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, AlfvenWaveUsesAlfvenSpeedAtLowBeta) {
+  Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, true);
+  SoundSpeed component("test", options, nullptr);
+
+  mesh->getCoordinates()->Bxy = 1.0;
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = 1.0;
+  options["species"]["i"]["AA"] = 1.0;
+
+  component.declareAllSpecies({"i"});
+  component.transform(options);
+
+  const BoutReal sound_speed = 1.0;
+  const BoutReal alfven_speed = getBetaNorm(options);
+
+  ASSERT_GT(alfven_speed, sound_speed);
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["sound_speed"]), sound_speed, "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(get<Field3D>(options["fastest_wave"]), alfven_speed, "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, ElectronDynamicsFalseExcludesElectronSpeciesSoundSpeed) {
+  Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, false, false);
+  SoundSpeed component("test", options, nullptr);
+
+  options["species"]["e"]["density"] = 1.0;
+  options["species"]["e"]["pressure"] = 8.0;
+  options["species"]["e"]["AA"] = 5e-4;
+  options["species"]["e"]["temperature"] = 100.0;
+
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = 1.0;
+  options["species"]["i"]["AA"] = 1.0;
+  options["species"]["i"]["temperature"] = 1.0;
+
+  component.declareAllSpecies({"e", "i"});
+  component.transform(options);
+
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["sound_speed"]), 3.0, "RGN_NOBNDRY"));
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]), 3.0, "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, FastestWaveFactorScalesFastestWaveOnly) {
+  Options options = makeSoundSpeedOptions(1.0, 1.0, 1.0, 1.0, 1.0, false, true, 1.7);
+  SoundSpeed component("test", options, nullptr);
+
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = 4.0;
+  options["species"]["i"]["AA"] = 1.0;
+
+  component.declareAllSpecies({"i"});
+  component.transform(options);
+
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["sound_speed"]), 2.0, "RGN_NOBNDRY"));
+  ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]), 3.4, "RGN_NOBNDRY"));
+}
+
+TEST_F(SoundSpeedTest, NonPeriodicBoundaryCellsAreSet) {
+  auto* fake_mesh = dynamic_cast<FakeMesh*>(mesh);
+  ASSERT_NE(fake_mesh, nullptr);
+  fake_mesh->ix_separatrix = 0;
+
+  Options options = makeSoundSpeedOptions();
+  SoundSpeed component("test", options, nullptr);
+
+  const Field3D input = makeYField({25.0, 4.0, 9.0, 16.0, 36.0});
+
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = input;
+  options["species"]["i"]["AA"] = 1.0;
+  options["species"]["i"]["temperature"] = input;
+
+  component.declareAllSpecies({"i"});
+  component.transform(options);
+
+  const auto sound_speed = get<Field3D>(options["sound_speed"]);
+  const auto fastest_wave = get<Field3D>(options["fastest_wave"]);
+
+  for (int x = mesh->xstart; x <= mesh->xend; ++x) {
+    for (int z = 0; z < mesh->LocalNz; ++z) {
+      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->ystart, z), 2.0);
+      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->yend, z), 4.0);
+      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->ystart, z), 2.0);
+      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->yend, z), 4.0);
+    }
+  }
+}
+
+TEST_F(PeriodicCommSoundSpeedTest, PeriodicGuardCellsAreCommunicated) {
+  Options options = makeSoundSpeedOptions();
+  SoundSpeed component("test", options, nullptr);
+
+  const Field3D input = makeYField({100.0, 4.0, 9.0, 16.0, 121.0});
+
+  options["species"]["i"]["density"] = 1.0;
+  options["species"]["i"]["pressure"] = input;
+  options["species"]["i"]["AA"] = 1.0;
+  options["species"]["i"]["temperature"] = input;
+
+  component.declareAllSpecies({"i"});
+  component.transform(options);
+
+  const auto sound_speed = get<Field3D>(options["sound_speed"]);
+  const auto fastest_wave = get<Field3D>(options["fastest_wave"]);
+
+  ASSERT_TRUE(
+      IsFieldEqual(sound_speed, makeYField({0.0, 2.0, 3.0, 4.0, 0.0}), "RGN_NOBNDRY"));
+  ASSERT_TRUE(
+      IsFieldEqual(fastest_wave, makeYField({0.0, 2.0, 3.0, 4.0, 0.0}), "RGN_NOBNDRY"));
+
+  for (int x = mesh->xstart; x <= mesh->xend; ++x) {
+    for (int z = 0; z < mesh->LocalNz; ++z) {
+      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->ystart - 1, z), 4.0);
+      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->yend + 1, z), 2.0);
+      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->ystart - 1, z), 4.0);
+      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->yend + 1, z), 2.0);
+    }
+  }
 }

--- a/tests/unit/test_sound_speed.cxx
+++ b/tests/unit/test_sound_speed.cxx
@@ -325,41 +325,6 @@ TEST_F(SoundSpeedTest, FastestWaveFactorScalesFastestWaveOnly) {
   ASSERT_TRUE(IsFieldEqual(get<Field3D>(options["fastest_wave"]), 3.4, "RGN_NOBNDRY"));
 }
 
-/// On a non-periodic mesh, Y boundary values should be overwritten by boundary
-/// handling rather than preserving the supplied edge-cell inputs.
-TEST_F(SoundSpeedTest, NonPeriodicBoundaryCellsAreSet) {
-  auto* fake_mesh = dynamic_cast<FakeMesh*>(mesh);
-  ASSERT_NE(fake_mesh, nullptr);
-  fake_mesh->ix_separatrix = 0;
-
-  Options options = makeSoundSpeedOptions();
-  SoundSpeed component("test", options, nullptr);
-
-  // Seed distinct edge values so the test can tell whether boundary handling
-  // overwrites them with the expected interior-adjacent values.
-  const Field3D input = makeYField({25.0, 4.0, 9.0, 16.0, 36.0});
-
-  options["species"]["i"]["density"] = 1.0;
-  options["species"]["i"]["pressure"] = input;
-  options["species"]["i"]["AA"] = 1.0;
-  options["species"]["i"]["temperature"] = input;
-
-  component.declareAllSpecies({"i"});
-  component.transform(options);
-
-  const auto sound_speed = get<Field3D>(options["sound_speed"]);
-  const auto fastest_wave = get<Field3D>(options["fastest_wave"]);
-
-  for (int x = mesh->xstart; x <= mesh->xend; ++x) {
-    for (int z = 0; z < mesh->LocalNz; ++z) {
-      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->ystart, z), 2.0);
-      EXPECT_DOUBLE_EQ(sound_speed(x, mesh->yend, z), 4.0);
-      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->ystart, z), 2.0);
-      EXPECT_DOUBLE_EQ(fastest_wave(x, mesh->yend, z), 4.0);
-    }
-  }
-}
-
 /// On a periodic mesh, Y guard cells should be populated by communication from
 /// the opposite interior edge after `sound_speed` and `fastest_wave` are computed.
 TEST_F(PeriodicCommSoundSpeedTest, PeriodicGuardCellsAreCommunicated) {


### PR DESCRIPTION
### Purpose
Fixes a bug that caused loss of conservation at processor edges. 

The sound_speed and fastest_wave fields are calculated in the domain but were not being communicated to fill guard cells. This meant that Lax fluxes calculated at the edges of processor boundaries were not consistent on either side of the boundary. This caused loss of conservation on processor edges.

### Change Summary
Adds communication of `sound_speed` and `fastest_wave` in the `sound_speed` component.

Adds communication of the fixed `N`, `T` and `V` in the `fixed_density`, `fixed_temperature` and `fixed_velocity` components.

### Validation
A new integrated test, `1D-density` that reproduced the original issues and passes with these fixes.

### AI Assistance
AI assistance in identifying the issue and to write unit tests.

### Documentation
No change to user-facing API.

### Review Notes
Thanks to Maurice at Uni. Geifswald for finding the issue and identifying the fix! 
See discussion on Zulip Hermes-3 channel.