### PR TITLE
Remove redundant install instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,49 +50,7 @@ LLNL-CODE-845139
 
 ## Installing and testing
 
-Only CMake is supported for building Hermes-3 and running the tests.
-During configuration
-[BOUT++](https://github.com/boutproject/BOUT-dev/) will be
-automatically downloaded as a submodule, together with some
-dependencies. [NetCDF](https://www.unidata.ucar.edu/software/netcdf/)
-and [FFTW](https://www.fftw.org/) are assumed to be installed already;
-optional dependencies include
-[SUNDIALS](https://computing.llnl.gov/projects/sundials) and
-[PETSc](https://petsc.org). The recommended way to build Hermes-3
-links to the [SUNDIALS](https://computing.llnl.gov/projects/sundials)
-library.
-
-1) Configure with cmake, downloading and linking to SUNDIALS:
-
-    $ cmake . -B build -DBOUT_DOWNLOAD_SUNDIALS=ON
-
-2) Build, compiling Hermes-3 and all dependencies:
-
-    $ cmake --build build
-
-3) Run the unit and integrated tests to check that everything is working:
-
-    $ cd build
-    $ ctest
-
-Note that the integrated tests require MPI, and so may not run on the
-head nodes of many computing clusters.
-
-The CMake configuration can be customised: See the [BOUT++
-documentation](https://bout-dev.readthedocs.io/en/latest/user_docs/installing.html#cmake)
-for examples of using `cmake` arguments, or edit the compile options
-interactively before building:
-
-    $ ccmake . -B build
-
-If you have already installed BOUT++ and want to use that rather than
-configure and build BOUT++ again, set `HERMES_BUILD_BOUT` to `OFF` and pass
-CMake the path to the BOUT++ `build` directory e.g.
-
-    $ cmake . -B build -DHERMES_BUILD_BOUT=OFF -DCMAKE_PREFIX_PATH=$HOME/BOUT-dev/build
-
-Note that Hermes-3 currently requires a specific version of BOUT++:
-https://github.com/boutproject/BOUT-dev/commit/7152948fbde505f6708d5ca4a9c21e5828d1e0a1
+Please refer to the [documentation](https://hermes3.readthedocs.io/en/latest/installation.html) for installation instructions.
 
 ## Examples
 

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -37,7 +37,8 @@ and compiled automatically for convenience. `FFTW
 Hermes-3 uses two solvers: `SUNDIALS <https://computing.llnl.gov/projects/sundials>`__ `cvode` for
 time-dependent simulations and the faster `PETSc
 <https://petsc.org>`__ `beuler` for steady-state transport problems. While SUNDIALS
-can be downloaded and installed automatically, PETSc requires manual installation.
+can be downloaded and installed automatically, PETSc requires manual installation when using CMake.
+Using the Spack installation methods provides PETSc automatically.
 
 Installing with SUNDIALS (cvode) only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,8 +66,13 @@ recommended way to build Hermes-3 links to the SUNDIALS library:
       cd build
       ctest
 
-Note that the integrated tests require MPI, and so may not run on the
-head nodes of many computing clusters.
+.. important::
+   The tests require an activated Python environment with `boutdata`, `xhermes` and their dependencies
+   (see https://hermes3.readthedocs.io/en/latest/postprocessing.html). They can be installed with `pip`.
+
+.. important::
+   Note that the integrated tests require MPI, and so may not run on the
+   head nodes of many computing clusters.
 
 
 Installing with SUNDIALS and PETSc (beuler)


### PR DESCRIPTION
### Purpose
<!-- What problem does this PR solve, or what capability does it add? Provide a link to any relevant issues or pull requests. -->
Readme now points at the documentation as a single source of truth for install instructions. I have also made minor changes to those.

### Change Summary
<!-- Briefly describe what was changed. -->
- Remove install instructions from readme and replace with link to docs
- Add a few words to the install docs, incl. that tests need our Python packages to work

### Validation
<!-- How did you verify this works? Include relevant tests, manual checks, or analysis. If not tested, say why. -->
N/A

### AI Assistance
<!-- Were AI tools used during development? If yes, briefly describe how, and how you verified their output. Remove this section if your PR does not contain AI-generated content. -->
None

### Documentation
<!-- What documentation was updated? If none, explain why no documentation changes were needed. -->
Yes

### Review Notes
<!-- Anything reviewers should pay particular attention to? For example: risks, limitations, things you're not sure about. -->

---

Resolves #450
