### PR TITLE
Cache BOUT++ builds in CI

### DIFF
--- a/.build_bout_for_ci.sh
+++ b/.build_bout_for_ci.sh
@@ -8,8 +8,8 @@ if [[ ! -d $HOME/local_bout/include/bout ]]; then
     echo "****************************************"
     mkdir -p external/BOUT-dev/build/ && cd external/BOUT-dev/build/
     cmake -DCMAKE_INSTALL_PREFIX="$HOME/local_bout" \
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-          $BOUT_CONFIGURE_OPTIONS
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          $BOUT_CONFIGURE_OPTIONS \
           ..
     make && make install
     echo "****************************************"

--- a/.build_bout_for_ci.sh
+++ b/.build_bout_for_ci.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ ! -d $HOME/local_bout/include/bout ]]; then
+    echo "****************************************"
+    echo "Building BOUT++"
+    echo "****************************************"
+    mkdir -p external/BOUT-dev/build/ && cd external/BOUT-dev/build/
+    cmake -DCMAKE_INSTALL_PREFIX="$HOME/local_bout" \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          $BOUT_CONFIGURE_OPTIONS
+          ..
+    make && make install
+    echo "****************************************"
+    echo "Finished building BOUT++"
+    echo "****************************************"
+else
+    echo "****************************************"
+    echo "BOUT++ already installed"
+    echo "****************************************"
+fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       MPIRUN: mpiexec -np
       LD_LIBRARY_PATH: /home/runner/local/lib:$LD_LIBRARY_PATH
       BOUT_CONFIGURE_OPTIONS: ${{ matrix.build_type.bout_configure_options }}
-      HERMES_CONFIGURE_OPTIONS: ${{ matrix.build_type.hermes_configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }} -Dbout++_ROOT=/home/runner/local_bout -DHERMES_BUILD_BOUT=OFF
+      HERMES_CONFIGURE_OPTIONS: ${{ matrix.build_type.hermes_configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }} -Dbout++_ROOT=/home/runner/local_bout -DHERMES_BUILD_BOUT=OFF -DHERMES_UPDATE_GIT_SUBMODULE=OFF
       BUILD_TYPE: ${{ matrix.build_type.cmake_build_type }}
       TEST_TYPE: ${{ matrix.build_type.test_type }}
       PETSC_DIR: /usr/lib/petscdir/petsc3.12/x86_64-linux-gnu-real
@@ -107,11 +107,18 @@ jobs:
       - name: Build SUNDIALS
         run: ./external/BOUT-dev/.build_sundials_for_ci.sh
 
-      - name: Construct BOUT++ cache key
+      - name: Install pip packages
+        run: |
+          ./ci/pip_install.sh
+          # Add the pip install location to the runner's PATH
+          echo ~/.local/bin >> $GITHUB_PATH
+
+      - name: Assemble BOUT++ build info
         run: |
           git submodule status external/BOUT-dev > bout_build_info.txt
           echo "Build type: $BUILD_TYPE" >> bout_build_info.txt
           echo "$BOUT_CONFIGURE_OPTIONS" >> bout_build_info.txt
+          pip freeze | grep numpy >> bout_build_info.txt
           echo "${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}" >> bout_build_info.txt
           cat bout_build_info.txt
 
@@ -119,16 +126,10 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /home/runner/local_bout
-          key: bout-${{ matrix.config.os }}-${{ hashFiles('bout_build_info.txt', '.build_bout_for_ci.sh') }}
+          key: bout-${{ matrix.config.os }}-${{ hashFiles('bout_build_info.txt', 'ci/build_bout_for_ci.sh') }}
 
       - name: Build BOUT++
-        run: ./.build_bout_for_ci.sh
-
-      - name: Install pip packages
-        run: |
-          ./ci/pip_install.sh
-          # Add the pip install location to the runner's PATH
-          echo ~/.local/bin >> $GITHUB_PATH
+        run: ./ci/build_bout_for_ci.sh
 
       - name: Build
         run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       MPIRUN: mpiexec -np
       LD_LIBRARY_PATH: /home/runner/local/lib:$LD_LIBRARY_PATH
       BOUT_CONFIGURE_OPTIONS: ${{ matrix.build_type.bout_configure_options }}
-      HERMES_CONFIGURE_OPTIONS: ${{ matrix.build_type.hermes_configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }} -DBOUT++_ROOT=/home/runner/local_bout
+      HERMES_CONFIGURE_OPTIONS: ${{ matrix.build_type.hermes_configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }} -Dbout++_ROOT=/home/runner/local_bout -DHERMES_BUILD_BOUT=OFF
       BUILD_TYPE: ${{ matrix.build_type.cmake_build_type }}
       TEST_TYPE: ${{ matrix.build_type.test_type }}
       PETSC_DIR: /usr/lib/petscdir/petsc3.12/x86_64-linux-gnu-real
@@ -108,22 +108,21 @@ jobs:
         run: ./external/BOUT-dev/.build_sundials_for_ci.sh
 
       - name: Construct BOUT++ cache key
-        id: bout-cache-key
         run: |
           git submodule status external/BOUT-dev > bout_build_info.txt
           echo "Build type: $BUILD_TYPE" >> bout_build_info.txt
           echo "$BOUT_CONFIGURE_OPTIONS" >> bout_build_info.txt
           echo "${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}" >> bout_build_info.txt
-          echo "bout_key=${{ hashFiles('bout_build_info.txt') }}" >> "$GITHUB_OUTPUT"
           cat bout_build_info.txt
-          echo "Github output:"
-          cat $GITHUB_OUTPUT
+          echo "Hash for these configs: ${{ hashFiles('bout_build_info.txt') }}"
+          echo "Hash for build script: ${{ hashFiles('.build_bout_for_ci.sh') }}"
+          echo "Combined hash: ${{ hashFiles('bout_build_info.txt', '.build_bout_for_ci.sh') }}"
 
       - name: Cache BOUT++ build
         uses: actions/cache@v6
         with:
           path: /home/runner/local_bout
-          key: bout-${{ matrix.config.os }}-${{ steps.bout-cache-key.outputs.bout_key }}
+          key: bout-${{ matrix.config.os }}-${{ hashFiles('bout_build_info.txt', '.build_bout_for_ci.sh') }}
 
       - name: Build BOUT++
         run: ./.build_bout_for_ci.sh
@@ -135,7 +134,7 @@ jobs:
           echo ~/.local/bin >> $GITHUB_PATH
 
       - name: Build
-        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS -DHERMES_BUILD_BOUT=OFF  &&
+        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS &&
              cmake --build build -j4
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,11 +110,14 @@ jobs:
       - name: Construct BOUT++ cache key
         id: bout-cache-key
         run: |
-          echo "$(git submodule status external/BOUT-dev)" > bout_build_info.txt
+          git submodule status external/BOUT-dev > bout_build_info.txt
           echo "Build type: $BUILD_TYPE" >> bout_build_info.txt
           echo "$BOUT_CONFIGURE_OPTIONS" >> bout_build_info.txt
           echo "${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}" >> bout_build_info.txt
           echo "bout_key=${{ hashFiles('bout_build_info.txt') }}" >> "$GITHUB_OUTPUT"
+          cat bout_build_info.txt
+          echo "Github output:"
+          cat $GITHUB_OUTPUT
 
       - name: Cache BOUT++ build
         uses: actions/cache@v6
@@ -132,7 +135,7 @@ jobs:
           echo ~/.local/bin >> $GITHUB_PATH
 
       - name: Build
-        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS &&
+        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS -DHERMES_BUILD_BOUT=OFF  &&
              cmake --build build -j4
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,12 @@ jobs:
             coverage: ON
             name: "3D metrics"
             bout_configure_options: "-DPACKAGE_TESTS=OFF -DBOUT_ENABLE_METRIC_3D=ON"
-            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON -DBOUT_ENABLE_METRIC_3D=ON"
           - cmake_build_type: Debug
             test_type: integration
             name: "3D metrics"
             bout_configure_options: "-DPACKAGE_TESTS=OFF -DBOUT_ENABLE_METRIC_3D=ON"
-            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON -DBOUT_ENABLE_METRIC_3D=ON"
             coverage: OFF
 
     steps:
@@ -114,9 +114,6 @@ jobs:
           echo "$BOUT_CONFIGURE_OPTIONS" >> bout_build_info.txt
           echo "${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}" >> bout_build_info.txt
           cat bout_build_info.txt
-          echo "Hash for these configs: ${{ hashFiles('bout_build_info.txt') }}"
-          echo "Hash for build script: ${{ hashFiles('.build_bout_for_ci.sh') }}"
-          echo "Combined hash: ${{ hashFiles('bout_build_info.txt', '.build_bout_for_ci.sh') }}"
 
       - name: Cache BOUT++ build
         uses: actions/cache@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,8 @@ jobs:
       OMPI_MCA_rmaps_base_oversubscribe: yes
       MPIRUN: mpiexec -np
       LD_LIBRARY_PATH: /home/runner/local/lib:$LD_LIBRARY_PATH
-      BOUT_CONFIGURE_OPTIONS: ${{ matrix.build_type.configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }}
+      BOUT_CONFIGURE_OPTIONS: ${{ matrix.build_type.bout_configure_options }}
+      HERMES_CONFIGURE_OPTIONS: ${{ matrix.build_type.hermes_configure_options }} -DHERMES_COVERAGE=${{ matrix.build_type.coverage }} -DBOUT++_ROOT=/home/runner/local_bout
       BUILD_TYPE: ${{ matrix.build_type.cmake_build_type }}
       TEST_TYPE: ${{ matrix.build_type.test_type }}
       PETSC_DIR: /usr/lib/petscdir/petsc3.12/x86_64-linux-gnu-real
@@ -37,27 +38,30 @@ jobs:
             test_type: unit
             coverage: ON
             name: "CMake default options"
-            configure_options: "-DPACKAGE_TESTS=OFF -DHERMES_ERROR_ON_WARNINGS=ON"
+            bout_configure_options: "-DPACKAGE_TESTS=OFF"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
           - cmake_build_type: Release
             test_type: integration
             coverage: OFF
             name: "CMake default options"
-            configure_options: "-DPACKAGE_TESTS=OFF
-                                -DHERMES_ERROR_ON_WARNINGS=ON
+            bout_configure_options: "-DPACKAGE_TESTS=OFF
                                 -DBOUT_USE_PETSC=ON
                                 -DBOUT_USE_SLEPC=ON
                                 -DBOUT_USE_SUNDIALS=ON
                                 -DSUNDIALS_ROOT=/home/runner/local
                                 -DBOUT_USE_HYPRE=ON"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
           - cmake_build_type: Debug
             test_type: unit
             coverage: ON
             name: "3D metrics"
-            configure_options: "-DPACKAGE_TESTS=OFF -DHERMES_ERROR_ON_WARNINGS=ON -DBOUT_ENABLE_METRIC_3D=ON"
+            bout_configure_options: "-DPACKAGE_TESTS=OFF -DBOUT_ENABLE_METRIC_3D=ON"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
           - cmake_build_type: Debug
             test_type: integration
             name: "3D metrics"
-            configure_options: "-DPACKAGE_TESTS=OFF -DHERMES_ERROR_ON_WARNINGS=ON -DBOUT_ENABLE_METRIC_3D=ON"
+            bout_configure_options: "-DPACKAGE_TESTS=OFF -DBOUT_ENABLE_METRIC_3D=ON"
+            hermes_configure_options: "-DHERMES_ERROR_ON_WARNINGS=ON"
             coverage: OFF
 
     steps:
@@ -98,10 +102,28 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /home/runner/local
-          key: bout-sundials-${{ matrix.config.os }}${{ matrix.config.build_petsc }}
+          key: bout-sundials-${{ matrix.config.os }}-${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}
 
       - name: Build SUNDIALS
         run: ./external/BOUT-dev/.build_sundials_for_ci.sh
+
+      - name: Construct BOUT++ cache key
+        id: bout-cache-key
+        run: |
+          echo "$(git submodule status external/BOUT-dev)" > bout_build_info.txt
+          echo "Build type: $BUILD_TYPE" >> bout_build_info.txt
+          echo "$BOUT_CONFIGURE_OPTIONS" >> bout_build_info.txt
+          echo "${{ hashFiles('./external/BOUT-dev/.build_sundials_for_ci.sh') }}" >> bout_build_info.txt
+          echo "bout_key=${{ hashFiles('bout_build_info.txt') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache BOUT++ build
+        uses: actions/cache@v6
+        with:
+          path: /home/runner/local_bout
+          key: bout-${{ matrix.config.os }}-${{ steps.bout-cache-key.outputs.bout_key }}
+
+      - name: Build BOUT++
+        run: ./.build_bout_for_ci.sh
 
       - name: Install pip packages
         run: |
@@ -110,7 +132,7 @@ jobs:
           echo ~/.local/bin >> $GITHUB_PATH
 
       - name: Build
-        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE  $BOUT_CONFIGURE_OPTIONS &&
+        run: cmake . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $HERMES_CONFIGURE_OPTIONS &&
              cmake --build build -j4
 
       - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ if(HERMES_REVISION STREQUAL "GITDIR-NOTFOUND")
 endif()
 message(STATUS "Git revision: ${HERMES_REVISION}")
 
+option(BUILD_SHARED_LIBS "Build shared libs" ON)
+
 # BOUT++ is a dependency
 option(HERMES_BUILD_BOUT "Build BOUT++ in external/BOUT-dev" ON)
 if(HERMES_BUILD_BOUT)

--- a/ci/build_bout_for_ci.sh
+++ b/ci/build_bout_for_ci.sh
@@ -10,7 +10,7 @@ if [[ ! -d $HOME/local_bout/include/bout ]]; then
     cmake -DCMAKE_INSTALL_PREFIX="$HOME/local_bout" \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           $BOUT_CONFIGURE_OPTIONS \
-          ..
+          -j4 ..
     make && make install
     echo "****************************************"
     echo "Finished building BOUT++"

--- a/ci/build_bout_for_ci.sh
+++ b/ci/build_bout_for_ci.sh
@@ -10,8 +10,8 @@ if [[ ! -d $HOME/local_bout/include/bout ]]; then
     cmake -DCMAKE_INSTALL_PREFIX="$HOME/local_bout" \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           $BOUT_CONFIGURE_OPTIONS \
-          -j4 ..
-    make && make install
+          ..
+    make  -j4 && make -j4 install
     echo "****************************************"
     echo "Finished building BOUT++"
     echo "****************************************"


### PR DESCRIPTION
### Purpose
This PR aims to speed up CI builds by caching the BOUT++ library. This means it will only need to be rebuilt when the commit of the `BOUT-dev` submodule or the build configs change.

### Change Summary
The `tests.yml` workflow was refactored to build BOUT++ separately from Hermes-3. A cache was set up to store the installed BOUT++ artifacts, modeled on how this is done for SUNDIALS.

### Validation
Will run in CI for this PR. Once I confirm that BOUT++ can be built I will rerun the workflow to check if it reuses the cached build.

### AI Assistance
None.

### Documentation
CI is not described in documentation.

### Review Notes
This is built on top of #428, so should wait for that to be merged before reviewing.