### PR TITLE
Implementation of simple K-model for self-consistent turbulent diffusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(HERMES_SOURCES
     src/cx_reaction.cxx
     src/ionisation.cxx
     src/izn_rec_reaction.cxx
+    src/kmodel.cxx
     src/div_ops.cxx
     src/neutral_mixed.cxx
     src/neutral_full_velocity.cxx
@@ -150,6 +151,7 @@ set(HERMES_SOURCES
     include/solkit_hydrogen_charge_exchange.hxx
     include/integrate.hxx
     include/ionisation.hxx
+    include/kmodel.hxx
     include/izn_rec_reaction.hxx
     include/neutral_boundary.hxx
     include/neutral_mixed.hxx

--- a/hermes-3.cxx
+++ b/hermes-3.cxx
@@ -56,6 +56,7 @@
 #include "include/ionisation.hxx"
 #include "include/isothermal.hxx"
 #include "include/izn_rec_reaction.hxx"
+#include "include/kmodel.hxx"
 #include "include/neutral_boundary.hxx"
 #include "include/neutral_full_velocity.hxx"
 #include "include/neutral_mixed.hxx"

--- a/include/kmodel.hxx
+++ b/include/kmodel.hxx
@@ -27,8 +27,6 @@ private:
 
   Field3D alpha;
 
-  Field3D gradPgradB_X, gradPgradB_Y, gradPgradB_Z;
-
   Field3D DDX_P, DDX_B;
 
   Field3D DDY_P, DDY_B;
@@ -58,7 +56,11 @@ private:
 
   bool diagnose;
 
-  bool diffusion, advection;
+  bool advection;
+
+  bool diffusion;
+
+  bool feedback;
 
   void transform_impl(GuardedOptions& state) override;
 };

--- a/include/kmodel.hxx
+++ b/include/kmodel.hxx
@@ -10,6 +10,8 @@
 
 struct Kmodel : public NamedComponent<Kmodel> {
 
+  static constexpr auto type = "kmodel";
+
   Kmodel(std::string name, Options& options, Solver* solver);
 
   void finally(const Options& state) override;
@@ -25,9 +27,11 @@ private:
 
   Field3D alpha;
 
-  Field3D gradPgradB_X, gradPgradB_Z;
+  Field3D gradPgradB_X, gradPgradB_Y, gradPgradB_Z;
 
   Field3D DDX_P, DDX_B;
+
+  Field3D DDY_P, DDY_B;
 
   Field3D DDZ_P, DDZ_B;
 
@@ -35,18 +39,32 @@ private:
 
   Field3D S_k, P_k;
 
+  Field3D klim;
+
   Field3D Bxy;
+
+  Field3D Pi_hat, Ni_hat;
 
   BoutReal R_major, R_minor;
 
   BoutReal L_par;
   BoutReal lambda_q;
-
+  BoutReal average_AA;
   Field3D SQ_lambda_SOL;
+
+  Field3D flux_k_x, flux_k_y;
 
   BoutReal chi_factor, nu_factor;
 
   bool diagnose;
+
+  bool diffusion, advection;
+
+  void transform_impl(GuardedOptions& state) override;
 };
+
+namespace {
+RegisterComponent<Kmodel> registercomponentkmodel;
+}
 
 #endif // KMODEL_H

--- a/include/kmodel.hxx
+++ b/include/kmodel.hxx
@@ -1,0 +1,52 @@
+#pragma once
+#ifndef KMODEL_H
+#define KMODEL_H
+
+#include "component.hxx"
+
+/// Evolve the turbulent kinetic energy with the k-model ansatz
+/// from H. Bufferand et al 2021 Nucl. Fusion 61 116052
+/// DOI: 10.1088/1741-4326/ac2873
+
+struct Kmodel : public NamedComponent<Kmodel> {
+
+  Kmodel(std::string name, Options& options, Solver* solver);
+
+  void finally(const Options& state) override;
+
+  void outputVars(Options& state) override;
+
+private:
+  Field3D k;
+
+  Field3D D_k;
+
+  Field3D chi_k, nu_k;
+
+  Field3D alpha;
+
+  Field3D gradPgradB_X, gradPgradB_Z;
+
+  Field3D DDX_P, DDX_B;
+
+  Field3D DDZ_P, DDZ_B;
+
+  Field3D gamma;
+
+  Field3D S_k, P_k;
+
+  Field3D Bxy;
+
+  BoutReal R_major, R_minor;
+
+  BoutReal L_par;
+  BoutReal lambda_q;
+
+  Field3D SQ_lambda_SOL;
+
+  BoutReal chi_factor, nu_factor;
+
+  bool diagnose;
+};
+
+#endif // KMODEL_H

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -65,7 +65,7 @@ Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
 
   advection = options["advection"]
                   .doc("Turn on advection of k via parallel ion flow?")
-                  .withDefault<bool>(true);
+                  .withDefault<bool>(false);
 
   substitutePermissions(
       "input", {"AA", "charge", "density", "pressure", "temperature", "velocity"});
@@ -186,14 +186,14 @@ void Kmodel::transform_impl(GuardedOptions& state) {
 
 void Kmodel::finally(const Options& state) {
 
-  ddt(k) = 0.0;
+  ddt(k) = S_k - P_k;
 
-  ddt(k) += S_k - P_k;
+  Field3D klim = floor(k, 1e-10);
 
   if (diffusion) {
     flux_k_x = 0.0;
     flux_k_y = 0.0;
-    ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, k, flux_k_x, flux_k_y);
+    ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, klim, flux_k_x, flux_k_y);
   }
 
   if (advection) {
@@ -235,7 +235,7 @@ void Kmodel::finally(const Options& state) {
       Field3DParallel V_hat = N * V / Ni_hat;
 
       Field3D dummy;
-      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, k, fastest_wave, dummy);
+      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, klim, fastest_wave, dummy);
     }
   }
 }
@@ -249,14 +249,14 @@ void Kmodel::outputVars(Options& state) {
   auto Lnorm = get<BoutReal>(state["rho_s0"]);
 
   state["k"].setAttributes({{"time_dimension", "t"},
-                            {"units", "C m^-3"},
-                            {"conversion", SI::qe * Nnorm},
+                            {"units", "m^2 s^-2"},
+                            {"conversion", Nnorm * Nnorm * Omega_ci * Omega_ci},
                             {"long_name", "Turbulent kinetic energy"},
                             {"source", "kmodel"}});
 
   set_with_attrs(state["D_k"], D_k,
                  {{"time_dimension", "t"},
-                  {"units", "m^2 / s"},
+                  {"units", "m^2 s^-1"},
                   {"conversion", Lnorm * Lnorm * Omega_ci},
                   {"standard_name", "Turbulent diffusion coefficient"},
                   {"long_name", "Turbulent diffusion coefficient"},

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -1,0 +1,264 @@
+#include "../include/kmodel.hxx"
+#include "../include/component.hxx"
+#include "../include/div_ops.hxx"
+#include "../include/guarded_options.hxx"
+#include "../include/hermes_build_config.hxx"
+#include "../include/hermes_utils.hxx"
+#include "../include/permissions.hxx"
+
+#include <bout/bout_types.hxx>
+#include <bout/boutexception.hxx>
+#include <bout/constants.hxx>
+#include <bout/derivs.hxx>
+#include <bout/difops.hxx>
+#include <bout/field.hxx>
+#include <bout/field3d.hxx>
+#include <bout/field_factory.hxx>
+#include <bout/fv_ops.hxx>
+#include <bout/globals.hxx>
+#include <bout/options.hxx>
+#include <bout/output.hxx>
+#include <bout/solver.hxx>
+
+#include <string>
+
+using bout::globals::mesh;
+
+Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
+    : NamedComponent(name, {readIfSet("species:{all_species}:{input}"),
+                            readOnly("sound_speed"), readOnly("fastest_wave"),
+                            readWrite("species:{all_species}:{output}")}) {
+
+  solver->add(k, "k");
+
+  auto& options = alloptions[name];
+  // Normalisations
+  const Options& units = alloptions["units"];
+  const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
+  const BoutReal Bnorm = units["Tesla"];
+  const BoutReal Lnorm = units["meters"];
+
+  diagnose = options["diagnose"].doc("Diagnostic output").withDefault<bool>(false);
+
+  R_major =
+      options["R_major"].doc("Major radius in meter.").withDefault<BoutReal>(1.6) / Lnorm;
+
+  R_minor =
+      options["R_minor"].doc("Minor radius in meter.").withDefault<BoutReal>(0.5) / Lnorm;
+
+  L_par = options["L_par"]
+              .doc("Parallel connection length in meter.")
+              .withDefault<BoutReal>(100.0)
+          / Lnorm;
+
+  lambda_q = options["lambda_q"]
+                 .doc("Heat flux fall off length in meter.")
+                 .withDefault<BoutReal>(0.008)
+             / Lnorm;
+
+  average_AA = options["average_AA"]
+                   .doc("Average atomic mass to calculate Pi_hat and Ni_hat.")
+                   .withDefault<BoutReal>(1.0);
+
+  diffusion =
+      options["diffusion"].doc("Turn on diffusion of k via D_K?").withDefault<bool>(true);
+
+  advection = options["advection"]
+                  .doc("Turn on advection of k via parallel ion flow?")
+                  .withDefault<bool>(true);
+
+  substitutePermissions(
+      "input", {"AA", "charge", "density", "pressure", "temperature", "velocity"});
+
+  substitutePermissions("output", {"density_source", "momentum_source", "energy_source"});
+}
+
+void Kmodel::transform_impl(GuardedOptions& state) {
+
+  auto fields = state["fields"];
+
+  auto coord = mesh->getCoordinates();
+
+  Bxy = coord->Bxy;
+
+  k.applyBoundary();
+  mesh->communicate(k);
+  k.applyParallelBoundary();
+
+  GuardedOptions allspecies = state["species"];
+
+  Pi_hat = 0.0;
+  Ni_hat = 0.0;
+
+  for (auto& kv : allspecies.getChildren()) {
+    GuardedOptions species = allspecies[kv.first]; // Note: Need non-const
+
+    // Skip if not charged or no pressure set
+    if (!(species.isSet("charge"))) {
+      continue;
+    }
+
+    // Electrons for now
+    auto q = get<BoutReal>(species["charge"]);
+    if (q < 0.0) {
+      continue;
+    }
+
+    // Skip if no pressure
+    if (!species.isSet("pressure")) {
+      continue;
+    }
+
+    const auto P = GET_NOBOUNDARY(Field3D, species["pressure"]);
+    const auto AA = get<BoutReal>(species["AA"]);
+
+    Pi_hat += P * AA / average_AA;
+
+    // Skip if no density
+    if (!species.isSet("density")) {
+      continue;
+    }
+
+    const auto N = GET_NOBOUNDARY(Field3D, species["density"]);
+
+    Ni_hat += N * AA / average_AA;
+  }
+
+  Pi_hat.applyBoundary("neumann");
+  Ni_hat.applyBoundary("neumann");
+  mesh->communicate(Pi_hat, Ni_hat);
+  Pi_hat.applyParallelBoundary("parallel_neumann_o1");
+  Ni_hat.applyParallelBoundary("parallel_neumann_o1");
+
+  if (!state.isSet("sound_speed")) {
+    throw BoutException("Sound speed not set but required for the k-model!");
+  }
+
+  Field3D c_s = get<Field3D>(state["sound_speed"]);
+
+  Field3D inv_sq_c_s = 1.0 / (c_s * c_s);
+
+  Field3D klim = floor(k, 1e-10);
+
+  gradPgradB_X = floor((DDX(Pi_hat) / Pi_hat) * (DDX(Bxy) / Bxy) / coord->g_11, 0.0);
+
+  if (k.isFci()) {
+    gradPgradB_Z = floor((DDZ(Pi_hat) / Pi_hat) * (DDZ(Bxy) / Bxy) / coord->g_33, 0.0);
+  } else {
+    gradPgradB_Y = floor((DDY(Pi_hat) / Pi_hat) * (DDY(Bxy) / Bxy) / coord->g_22, 0.0);
+  }
+
+  DDX_P = DDX(Pi_hat) / sqrt(coord->g_11);
+  DDX_B = DDX(Bxy) / sqrt(coord->g_11);
+
+  if (k.isFci()) {
+    DDZ_P = DDZ(Pi_hat) / sqrt(coord->g_33);
+    DDZ_B = DDZ(Bxy) / sqrt(coord->g_33);
+  } else {
+    DDY_P = DDY(Pi_hat) / sqrt(coord->g_22);
+    DDY_B = DDY(Bxy) / sqrt(coord->g_22);
+  }
+
+  gamma = 0.0;
+
+  BOUT_FOR(i, Pi_hat.getRegion("RGN_NOY")) {
+    BoutReal grads = k.isFci() ? (DDX_P[i] / Pi_hat[i]) * (DDX_B[i] / Bxy[i])
+                                     + (DDZ_P[i] / Pi_hat[i]) * (DDZ_B[i] / Bxy[i])
+                               : (DDX_P[i] / Pi_hat[i]) * (DDX_B[i] / Bxy[i])
+                                     + (DDY_P[i] / Pi_hat[i]) * (DDY_B[i] / Bxy[i]);
+    gamma[i] = c_s[i] * sqrt(std::max(grads, 0.0));
+  }
+
+  S_k = gamma * klim;
+
+  D_k = R_major * klim / floor(c_s, 1e-10);
+
+  D_k = softFloor(D_k, 1e-5);
+
+  D_k.applyBoundary("neumann");
+  mesh->communicate(D_k);
+  D_k.applyParallelBoundary("parallel_neumann_o1");
+
+  alpha = R_major * L_par * gamma * inv_sq_c_s / (lambda_q * lambda_q);
+
+  P_k = alpha * klim * klim;
+}
+
+void Kmodel::finally(const Options& state) {
+
+  ddt(k) = 0.0;
+
+  ddt(k) += S_k - P_k;
+
+  if (diffusion) {
+    flux_k_x = 0.0;
+    flux_k_y = 0.0;
+    ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, k, flux_k_x, flux_k_y);
+  }
+
+  if (advection) {
+
+    for (const auto& kv : state["species"].getChildren()) {
+
+      const Options& species = kv.second;
+
+      // Skip if not charged
+      if (!(species.isSet("charge"))) {
+        continue;
+      }
+
+      // Electrons for now
+      auto q = get<BoutReal>(species["charge"]);
+      if (q < 0.0) {
+        continue;
+      }
+
+      // Skip if no pressure, density or velocity set
+      if (!species.isSet("pressure") or !species.isSet("density")
+          or !species.isSet("velocity")) {
+        continue;
+      }
+
+      // Typical wave speed used for numerical diffusion
+      Field3D fastest_wave;
+      if (state.isSet("fastest_wave")) {
+        fastest_wave = get<Field3D>(state["fastest_wave"]);
+      } else {
+        Field3D T = get<Field3D>(species["temperature"]);
+        const BoutReal AA = get<BoutReal>(species["AA"]);
+        fastest_wave = sqrt(T / AA);
+      }
+
+      Field3D N = get<Field3D>(species["density"]);
+      Field3D V = get<Field3D>(species["temperature"]);
+
+      Field3DParallel V_hat = N * V / average_AA;
+
+      Field3D dummy;
+      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, k, fastest_wave, dummy);
+    }
+  }
+}
+
+void Kmodel::outputVars(Options& state) {
+
+  // Normalisations
+  auto Nnorm = get<BoutReal>(state["Nnorm"]);
+  auto Tnorm = get<BoutReal>(state["Tnorm"]);
+  auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
+  auto Lnorm = get<BoutReal>(state["rho_s0"]);
+
+  state["k"].setAttributes({{"time_dimension", "t"},
+                            {"units", "C m^-3"},
+                            {"conversion", SI::qe * Nnorm},
+                            {"long_name", "Turbulent kinetic energy"},
+                            {"source", "kmodel"}});
+
+  set_with_attrs(state["D_k"], D_k,
+                 {{"time_dimension", "t"},
+                  {"units", "m^2 / s"},
+                  {"conversion", Lnorm * Lnorm * Omega_ci},
+                  {"standard_name", "Turbulent diffusion coefficient"},
+                  {"long_name", "Turbulent diffusion coefficient"},
+                  {"source", "kmodel"}});
+}

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -181,14 +181,10 @@ void Kmodel::transform_impl(GuardedOptions& state) {
       Field3D N = get<Field3D>(species["density"]);
       Field3D V = get<Field3D>(species["velocity"]);
       Field3D T = get<Field3D>(species["temperature"]);
-      const BoutReal AA = get<BoutReal>(species["AA"]);
 
       Field3D dummy1, dummy2;
       add(species["density_source"],
           Div_a_Grad_perp_upwind_flows(D_k, N, dummy1, dummy2));
-
-      //add(species["momentum_source"],
-      //	  Div_a_Grad_perp_upwind_flows(AA * V * D_k, N, dummy1, dummy2));
 
       add(species["energy_source"],
           Div_a_Grad_perp_upwind_flows((3.0 / 2.0) * T * D_k, N, dummy1, dummy2));

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -34,8 +34,6 @@ Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
   auto& options = alloptions[name];
   // Normalisations
   const Options& units = alloptions["units"];
-  const BoutReal Omega_ci = 1. / units["seconds"].as<BoutReal>();
-  const BoutReal Bnorm = units["Tesla"];
   const BoutReal Lnorm = units["meters"];
 
   diagnose = options["diagnose"].doc("Diagnostic output").withDefault<bool>(false);
@@ -240,7 +238,6 @@ void Kmodel::outputVars(Options& state) {
 
   // Normalisations
   auto Nnorm = get<BoutReal>(state["Nnorm"]);
-  auto Tnorm = get<BoutReal>(state["Tnorm"]);
   auto Omega_ci = get<BoutReal>(state["Omega_ci"]);
   auto Lnorm = get<BoutReal>(state["rho_s0"]);
 

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -18,6 +18,7 @@
 #include <bout/globals.hxx>
 #include <bout/options.hxx>
 #include <bout/output.hxx>
+#include <bout/output_bout_types.hxx>
 #include <bout/solver.hxx>
 
 #include <string>
@@ -64,6 +65,10 @@ Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
   advection = options["advection"]
                   .doc("Turn on advection of k via parallel ion flow?")
                   .withDefault<bool>(false);
+
+  feedback = options["feedback"]
+                 .doc("Feedback the diffusion coefficients to the species?")
+                 .withDefault<bool>(false);
 
   substitutePermissions(
       "input", {"AA", "charge", "density", "pressure", "temperature", "velocity"});
@@ -137,34 +142,11 @@ void Kmodel::transform_impl(GuardedOptions& state) {
 
   Field3D inv_sq_c_s = 1.0 / (c_s * c_s);
 
-  gradPgradB_X = floor((DDX(Pi_hat) / Pi_hat) * (DDX(Bxy) / Bxy) / coord->g_11, 0.0);
-
-  if (k.isFci()) {
-    gradPgradB_Z = floor((DDZ(Pi_hat) / Pi_hat) * (DDZ(Bxy) / Bxy) / coord->g_33, 0.0);
-  } else {
-    gradPgradB_Y = floor((DDY(Pi_hat) / Pi_hat) * (DDY(Bxy) / Bxy) / coord->g_22, 0.0);
-  }
-
-  DDX_P = DDX(Pi_hat) / sqrt(coord->g_11);
-  DDX_B = DDX(Bxy) / sqrt(coord->g_11);
-
-  if (k.isFci()) {
-    DDZ_P = DDZ(Pi_hat) / sqrt(coord->g_33);
-    DDZ_B = DDZ(Bxy) / sqrt(coord->g_33);
-  } else {
-    DDY_P = DDY(Pi_hat) / sqrt(coord->g_22);
-    DDY_B = DDY(Bxy) / sqrt(coord->g_22);
-  }
-
   gamma = 0.0;
 
-  BOUT_FOR(i, Pi_hat.getRegion("RGN_NOY")) {
-    BoutReal grads = k.isFci() ? (DDX_P[i] / Pi_hat[i]) * (DDX_B[i] / Bxy[i])
-                                     + (DDZ_P[i] / Pi_hat[i]) * (DDZ_B[i] / Bxy[i])
-                               : (DDX_P[i] / Pi_hat[i]) * (DDX_B[i] / Bxy[i])
-                                     + (DDY_P[i] / Pi_hat[i]) * (DDY_B[i] / Bxy[i]);
-    gamma[i] = c_s[i] * sqrt(std::max(grads, 0.0));
-  }
+  Field3D gradPgradB = floor(Grad_perp(Pi_hat) * Grad_perp(Bxy) / (Pi_hat * Bxy), 0.0);
+
+  gamma = c_s * sqrt(gradPgradB);
 
   S_k = gamma * k;
 
@@ -179,6 +161,39 @@ void Kmodel::transform_impl(GuardedOptions& state) {
   alpha = R_major * L_par * gamma * inv_sq_c_s / (lambda_q * lambda_q);
 
   P_k = alpha * k * k;
+
+  // Feedback now also to the electrons
+  if (feedback) {
+    for (auto& kv : allspecies.getChildren()) {
+      GuardedOptions species = allspecies[kv.first]; // Note: Need non-const
+
+      // Skip if not charged
+      if (!(species.isSet("charge"))) {
+        continue;
+      }
+
+      // Skip if no pressure, density or velocity set
+      if (!species.isSet("pressure") or !species.isSet("density")
+          or !species.isSet("velocity")) {
+        continue;
+      }
+
+      Field3D N = get<Field3D>(species["density"]);
+      Field3D V = get<Field3D>(species["velocity"]);
+      Field3D T = get<Field3D>(species["temperature"]);
+      const BoutReal AA = get<BoutReal>(species["AA"]);
+
+      Field3D dummy1, dummy2;
+      add(species["density_source"],
+          Div_a_Grad_perp_upwind_flows(D_k, N, dummy1, dummy2));
+
+      //add(species["momentum_source"],
+      //	  Div_a_Grad_perp_upwind_flows(AA * V * D_k, N, dummy1, dummy2));
+
+      add(species["energy_source"],
+          Div_a_Grad_perp_upwind_flows((3.0 / 2.0) * T * D_k, N, dummy1, dummy2));
+    }
+  } // Feedback
 }
 
 void Kmodel::finally(const Options& state) {
@@ -191,46 +206,48 @@ void Kmodel::finally(const Options& state) {
     ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, k, flux_k_x, flux_k_y);
   }
 
-  if (advection) {
+  for (const auto& kv : state["species"].getChildren()) {
 
-    for (const auto& kv : state["species"].getChildren()) {
+    const Options& species = kv.second;
 
-      const Options& species = kv.second;
-
-      // Skip if not charged
-      if (!(species.isSet("charge"))) {
-        continue;
-      }
-
-      // Electrons for now
-      auto q = get<BoutReal>(species["charge"]);
-      if (q < 0.0) {
-        continue;
-      }
-
-      // Skip if no pressure, density or velocity set
-      if (!species.isSet("pressure") or !species.isSet("density")
-          or !species.isSet("velocity")) {
-        continue;
-      }
-
-      // Typical wave speed used for numerical diffusion
-      Field3D fastest_wave;
-      if (state.isSet("fastest_wave")) {
-        fastest_wave = get<Field3D>(state["fastest_wave"]);
-      } else {
-        Field3D T = get<Field3D>(species["temperature"]);
-        const BoutReal AA = get<BoutReal>(species["AA"]);
-        fastest_wave = sqrt(T / AA);
-      }
-
-      Field3D N = get<Field3D>(species["density"]);
-      Field3D V = get<Field3D>(species["velocity"]);
-
-      Field3DParallel V_hat = N * V / Ni_hat;
-
-      ddt(k) -= V_hat * Div_par(k);
+    // Skip if not charged
+    if (!(species.isSet("charge"))) {
+      continue;
     }
+
+    // Skip if no pressure, density or velocity set
+    if (!species.isSet("pressure") or !species.isSet("density")
+        or !species.isSet("velocity")) {
+      continue;
+    }
+
+    Field3D N = get<Field3D>(species["density"]);
+    Field3D V = get<Field3D>(species["velocity"]);
+    const BoutReal AA = get<BoutReal>(species["AA"]);
+
+    // Skip if not using advection
+    if (!advection) {
+      continue;
+    }
+
+    // Electrons for now
+    auto q = get<BoutReal>(species["charge"]);
+    if (q < 0.0) {
+      continue;
+    }
+
+    // Typical wave speed used for numerical diffusion
+    Field3D fastest_wave;
+    if (state.isSet("fastest_wave")) {
+      fastest_wave = get<Field3D>(state["fastest_wave"]);
+    } else {
+      Field3D T = get<Field3D>(species["temperature"]);
+      fastest_wave = sqrt(T / AA);
+    }
+
+    Field3DParallel V_hat = N * V / Ni_hat;
+
+    ddt(k) -= V_hat * Div_par(k);
   }
 }
 

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -232,7 +232,7 @@ void Kmodel::finally(const Options& state) {
       Field3D N = get<Field3D>(species["density"]);
       Field3D V = get<Field3D>(species["temperature"]);
 
-      Field3DParallel V_hat = N * V / average_AA;
+      Field3DParallel V_hat = N * V / Ni_hat;
 
       Field3D dummy;
       ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, k, fastest_wave, dummy);

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -230,7 +230,7 @@ void Kmodel::finally(const Options& state) {
       }
 
       Field3D N = get<Field3D>(species["density"]);
-      Field3D V = get<Field3D>(species["temperature"]);
+      Field3D V = get<Field3D>(species["velocity"]);
 
       Field3DParallel V_hat = N * V / Ni_hat;
 

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -231,8 +231,7 @@ void Kmodel::finally(const Options& state) {
 
       Field3DParallel V_hat = N * V / Ni_hat;
 
-      Field3D dummy;
-      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, k, fastest_wave, dummy);
+      ddt(k) -= V_hat * Div_par(k);
     }
   }
 }

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -26,9 +26,10 @@
 using bout::globals::mesh;
 
 Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
-    : NamedComponent(name, {readIfSet("species:{all_species}:{input}"),
-                            readOnly("sound_speed"), readOnly("fastest_wave"),
-                            readWrite("species:{all_species}:{output}")}) {
+    : NamedComponent(name,
+                     {readIfSet("species:{all_species}:{input}"), readOnly("sound_speed"),
+                      readOnly("fastest_wave"), readWrite("fields:D_k"),
+                      readWrite("species:{all_species}:{output}")}) {
 
   solver->add(k, "k");
 
@@ -77,8 +78,6 @@ Kmodel::Kmodel(std::string name, Options& alloptions, Solver* solver)
 }
 
 void Kmodel::transform_impl(GuardedOptions& state) {
-
-  auto fields = state["fields"];
 
   auto coord = mesh->getCoordinates();
 
@@ -190,6 +189,8 @@ void Kmodel::transform_impl(GuardedOptions& state) {
           Div_a_Grad_perp_upwind_flows((3.0 / 2.0) * T * D_k, N, dummy1, dummy2));
     }
   } // Feedback
+
+  set(state["fields"]["D_k"], D_k);
 }
 
 void Kmodel::finally(const Options& state) {

--- a/src/kmodel.cxx
+++ b/src/kmodel.cxx
@@ -81,6 +81,7 @@ void Kmodel::transform_impl(GuardedOptions& state) {
 
   Bxy = coord->Bxy;
 
+  k = floor(k, 1e-12);
   k.applyBoundary();
   mesh->communicate(k);
   k.applyParallelBoundary();
@@ -138,8 +139,6 @@ void Kmodel::transform_impl(GuardedOptions& state) {
 
   Field3D inv_sq_c_s = 1.0 / (c_s * c_s);
 
-  Field3D klim = floor(k, 1e-10);
-
   gradPgradB_X = floor((DDX(Pi_hat) / Pi_hat) * (DDX(Bxy) / Bxy) / coord->g_11, 0.0);
 
   if (k.isFci()) {
@@ -169,11 +168,11 @@ void Kmodel::transform_impl(GuardedOptions& state) {
     gamma[i] = c_s[i] * sqrt(std::max(grads, 0.0));
   }
 
-  S_k = gamma * klim;
+  S_k = gamma * k;
 
-  D_k = R_major * klim / floor(c_s, 1e-10);
+  D_k = R_major * k / floor(c_s, 1e-10);
 
-  D_k = softFloor(D_k, 1e-5);
+  D_k = softFloor(D_k, 1e-8);
 
   D_k.applyBoundary("neumann");
   mesh->communicate(D_k);
@@ -181,19 +180,17 @@ void Kmodel::transform_impl(GuardedOptions& state) {
 
   alpha = R_major * L_par * gamma * inv_sq_c_s / (lambda_q * lambda_q);
 
-  P_k = alpha * klim * klim;
+  P_k = alpha * k * k;
 }
 
 void Kmodel::finally(const Options& state) {
 
   ddt(k) = S_k - P_k;
 
-  Field3D klim = floor(k, 1e-10);
-
   if (diffusion) {
     flux_k_x = 0.0;
     flux_k_y = 0.0;
-    ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, klim, flux_k_x, flux_k_y);
+    ddt(k) += Div_a_Grad_perp_upwind_flows(D_k, k, flux_k_x, flux_k_y);
   }
 
   if (advection) {
@@ -235,7 +232,7 @@ void Kmodel::finally(const Options& state) {
       Field3DParallel V_hat = N * V / Ni_hat;
 
       Field3D dummy;
-      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, klim, fastest_wave, dummy);
+      ddt(k) -= FV::Div_par_mod<hermes::Limiter>(V_hat, k, fastest_wave, dummy);
     }
   }
 }
@@ -261,4 +258,28 @@ void Kmodel::outputVars(Options& state) {
                   {"standard_name", "Turbulent diffusion coefficient"},
                   {"long_name", "Turbulent diffusion coefficient"},
                   {"source", "kmodel"}});
+
+  if (diagnose) {
+    set_with_attrs(state["Ni_hat"], Ni_hat,
+                   {{"time_dimension", "t"},
+                    {"units", "m^-3"},
+                    {"conversion", Nnorm},
+                    {"standard_name", "Average ion density"},
+                    {"long_name", "Average ion density"},
+                    {"source", "kmodel"}});
+
+    set_with_attrs(state["S_k"], S_k,
+                   {{"time_dimension", "t"},
+                    {"units", "m^2 s^-3"},
+                    {"conversion", Nnorm * Nnorm * Omega_ci * Omega_ci * Omega_ci},
+                    {"standard_name", "Generation of turbulent energy"},
+                    {"source", "kmodel"}});
+
+    set_with_attrs(state["P_k"], P_k,
+                   {{"time_dimension", "t"},
+                    {"units", "m^2 s^-3"},
+                    {"conversion", Nnorm * Nnorm * Omega_ci * Omega_ci * Omega_ci},
+                    {"standard_name", "Dissipation of turbulent energy"},
+                    {"source", "kmodel"}});
+  }
 }

--- a/tests/unit/test_kmodel.cxx
+++ b/tests/unit/test_kmodel.cxx
@@ -33,3 +33,26 @@ TEST_F(KmodelTest, CreateComponent) {
 
   ASSERT_TRUE(state.isSet("k"));
 }
+
+TEST_F(KmodelTest, Transform) {
+  FakeSolver solver;
+
+  Options::root()["mesh"]["paralleltransform"]["type"] = "shifted";
+  Options options{{"units", {{"seconds", 1.0}, {"Tesla", 1.0}, {"meters", 1.0}}}};
+
+  Permissions permissions{{readOnly("fields"), readWrite("fields:D_k")}};
+
+  Kmodel component("test", options, &solver);
+
+  Options state = solver.getState();
+
+  Field3D A = FieldFactory::get()->create3D("1 + y * (x - 0.5)", &options, mesh);
+  mesh->communicate(A);
+  mesh->getCoordinates()->Bxy = 1.0;
+  state["sound_speed"] = A;
+  state["fastest_wave"] = A;
+
+  component.transform(state);
+  ASSERT_TRUE(state.isSet("k"));
+  ASSERT_TRUE(state["fields"].isSet("D_k"));
+}

--- a/tests/unit/test_kmodel.cxx
+++ b/tests/unit/test_kmodel.cxx
@@ -1,0 +1,34 @@
+#include "gtest/gtest.h"
+
+#include "fake_mesh_fixture.hxx"
+#include "test_extras.hxx" // FakeMesh
+
+#include "../../include/kmodel.hxx"
+
+/// Global mesh
+namespace bout {
+namespace globals {
+extern Mesh* mesh;
+} // namespace globals
+} // namespace bout
+
+// The unit tests use the global mesh
+using namespace bout::globals;
+
+#include <bout/field_factory.hxx> // For generating functions
+
+// Reuse the "standard" fixture for FakeMesh
+using KmodelTest = FakeMeshFixture;
+
+TEST_F(KmodelTest, CreateComponent) {
+  FakeSolver solver;
+
+  Options::root()["mesh"]["paralleltransform"]["type"] = "shifted";
+  Options options{{"units", {{"seconds", 1.0}, {"Tesla", 1.0}, {"meters", 1.0}}}};
+
+  Kmodel component("test", options, &solver);
+
+  Options state = solver.getState();
+
+  ASSERT_TRUE(state.isSet("k"));
+}

--- a/tests/unit/test_kmodel.cxx
+++ b/tests/unit/test_kmodel.cxx
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "fake_mesh_fixture.hxx"
+#include "fake_solver.hxx"
 #include "test_extras.hxx" // FakeMesh
 
 #include "../../include/kmodel.hxx"


### PR DESCRIPTION
### Purpose
Anomalous transport coefficients are usually an input parameter of transport simulations, frequently chosen to be on the order of 0.1 to 1 m²/s. Turbulent transport in tokamaks is is often expected to be ballooned, meaning that there is larger transport on the low-field side compared to the high field side due to the good- and bad curvature regions and the following stabilization of instabilities that drive turbulence. This dynamics is generally hard to reproduce with ad-hoc spatially homogeneous coefficients. This model tries to increase the fidelity of transport coefficients by a bit, by evolving the turbulent kinetic energy from which diffusion coefficients can be obtained. The model is taken from https://doi.org/10.1088/1741-4326/ac2873. Example figure shown below. 
<img width="960" height="800" alt="D_turb" src="https://github.com/user-attachments/assets/1501c32c-50f2-40de-a71a-49b83c7fe27b" />



### Change Summary

- [x] Implement the equations of the turbulent kinetic energy k
- [ ] Work out the role of parallel transport here, currently the parallel advection causes problems
- [ ] Use the obtained diffusion coefficients as an additional diffusive process for all other species



### Validation
WIP: Probably a combination of unit and mms tests, with maybe an example of ballooning.

### AI Assistance
None

### Documentation
Remains to be done

### Review Notes
Initial progress. Results seem promising but some problems are still tricky. I am not sure what a healthy choice of BCs is here. Wanted to make the PR early if there are some conflicts or other developments. 
